### PR TITLE
[BREAKING CHANGES] Refactor parser categories

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -31,6 +31,7 @@ Layout/LineLength:
   Max: 100
   Exclude:
     - 'lib/app_info/helper/signatures.rb'
+    - 'lib/app_info/android/signatures/info.rb'
     - 'lib/app_info/apk.rb'
 
 Lint/AssignmentInCondition:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -31,6 +31,7 @@ Layout/LineLength:
   Max: 100
   Exclude:
     - 'lib/app_info/helper/signatures.rb'
+    - 'lib/app_info/apk.rb'
 
 Lint/AssignmentInCondition:
   Enabled: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Add `AppInfo::Certifiate` X509 certificate wrapped and apply in Android/MobileProvision.
 - Remove `AppInfo::MobileProvision::DeveloperCertificate` class, use `AppInfo::Certifiate` instead.
 - Remove `.sign_version` method in Android parser.
+- Rename `.os` to `.platform` method in all parers.
+- Rename `.file_type` to `.format` method in all parers and return a `AppInfo::Format` type.
 - Remove duplice `AppInfo::AndroidDevice` class.
 - Deprecate `.signs` and `.certifiates` methods in Android parser, use `.signatures` instead.
 - Deprecate `.developer_certs` method in MobileProvision parser, use `.certificates` instead.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 - Add `AppInfo::File` base class for all parsers.
 - Add `AppInfo::Certifiate` X509 certificate wrapped and apply in Android/MobileProvision.
-- Re-orgainze categories `.platform`, `.opera_sytem` and `.device` for all parsers. [#58](https://github.com/icyleaf/app_info/pull/58)
+- Re-organize categories `.platform`, `.opera_sytem` and `.device` for all parsers. [#58](https://github.com/icyleaf/app_info/pull/58)
+- Change ExportType values type to symbol both IPA and macOS parsers. [#58](https://github.com/icyleaf/app_info/pull/58)
 - Remove `.sign_version` method in Android parser.
 - Rename `.file_type` to `.format` method in all parers and return a `AppInfo::Format` type.
 - Remove duplice `AppInfo::AndroidDevice` class.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,16 +16,17 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - New Windows PE format parser. [#47](https://github.com/icyleaf/app_info/pull/47)
 - Android parser add v2, v3 scheme signature support. [#55](https://github.com/icyleaf/app_info/pull/55]
 - dSYM parer accept multi dSYM target in a zip file. [#56](https://github.com/icyleaf/app_info/pull/56)
+- Better document for yardoc.
 
 ### Changed
 
 - Add `AppInfo::File` base class for all parsers.
 - Add `AppInfo::Certifiate` X509 certificate wrapped and apply in Android/MobileProvision.
-- Remove `AppInfo::MobileProvision::DeveloperCertificate` class, use `AppInfo::Certifiate` instead.
+- Re-orgainze categories `.platform`, `.opera_sytem` and `.device` for all parsers. [#58](https://github.com/icyleaf/app_info/pull/58)
 - Remove `.sign_version` method in Android parser.
-- Rename `.os` to `.platform` method in all parers.
 - Rename `.file_type` to `.format` method in all parers and return a `AppInfo::Format` type.
 - Remove duplice `AppInfo::AndroidDevice` class.
+- Remove `AppInfo::MobileProvision::DeveloperCertificate` class, use `AppInfo::Certifiate` instead.
 - Deprecate `.signs` and `.certifiates` methods in Android parser, use `.signatures` instead.
 - Deprecate `.developer_certs` method in MobileProvision parser, use `.certificates` instead.
 

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
-# app_info
+# app-info
 
-[![Language](https://img.shields.io/badge/ruby-2.5+-701516.svg)](.github/workflows/ci.yml)
+[![Language](https://img.shields.io/badge/ruby-2.5+-701516)](.github/workflows/ci.yml)
+[![Gem version](https://img.shields.io/gem/v/app-info?include_prereleases)](https://rubygems.org/gems/app-info)
 [![Build Status](https://img.shields.io/github/actions/workflow/status/icyleaf/app_info/ci.yml)](https://github.com/icyleaf/app_info/actions/workflows/ci.yml)
-[![Gem version](https://img.shields.io/gem/v/app-info.svg?style=flat)](https://rubygems.org/gems/app-info)
-[![License](https://img.shields.io/badge/license-MIT-red.svg?style=flat)](LICENSE)
+[![License](https://img.shields.io/github/license/icyleaf/app-info)](LICENSE)
 
 Teardown tool for mobile app (ipa, apk and aab file), macOS app, dSYM.zip file and Windows PE file.
 Analysis metedata like version, name, icon etc.

--- a/lib/app_info.rb
+++ b/lib/app_info.rb
@@ -11,6 +11,8 @@ require 'app_info/file'
 require 'app_info/info_plist'
 require 'app_info/mobile_provision'
 
+require 'app_info/apple'
+require 'app_info/macos'
 require 'app_info/ipa'
 require 'app_info/ipa/plugin'
 require 'app_info/ipa/framework'
@@ -22,7 +24,6 @@ require 'app_info/aab'
 require 'app_info/proguard'
 require 'app_info/dsym'
 
-require 'app_info/macos'
 require 'app_info/pe'
 
 # fix invaild date format warnings

--- a/lib/app_info.rb
+++ b/lib/app_info.rb
@@ -45,7 +45,7 @@ module AppInfo
                when Format::MACOS then Macos.new(file)
                when Format::PE then PE.new(file)
                else
-                 raise UnknownFileTypeError, "Do not detect file type: #{file}"
+                 raise UnknownFormatError, "Do not detect file format: #{file}"
                end
 
       return parser unless block_given?

--- a/lib/app_info.rb
+++ b/lib/app_info.rb
@@ -17,7 +17,7 @@ require 'app_info/ipa'
 require 'app_info/ipa/plugin'
 require 'app_info/ipa/framework'
 
-require 'app_info/android/signature'
+require 'app_info/android'
 require 'app_info/apk'
 require 'app_info/aab'
 

--- a/lib/app_info/aab.rb
+++ b/lib/app_info/aab.rb
@@ -10,8 +10,6 @@ module AppInfo
     include Helper::HumanFileSize
     extend Forwardable
 
-    attr_reader :file
-
     BASE_PATH = 'base'
     BASE_MANIFEST = "#{BASE_PATH}/manifest/AndroidManifest.xml"
     BASE_RESOURCES = "#{BASE_PATH}/resources.pb"

--- a/lib/app_info/aab.rb
+++ b/lib/app_info/aab.rb
@@ -1,56 +1,13 @@
 # frozen_string_literal: true
 
 require 'app_info/protobuf/manifest'
-require 'image_size'
-require 'forwardable'
 
 module AppInfo
   # Parse APK file parser
-  class AAB < File
-    include Helper::HumanFileSize
-    extend Forwardable
-
+  class AAB < Android
     BASE_PATH = 'base'
     BASE_MANIFEST = "#{BASE_PATH}/manifest/AndroidManifest.xml"
     BASE_RESOURCES = "#{BASE_PATH}/resources.pb"
-
-    # return file size
-    # @example Read file size in integer
-    #   aab.size                    # => 3618865
-    #
-    # @example Read file size in human readabale
-    #   aab.size(human_size: true)  # => '3.45 MB'
-    #
-    # @param [Boolean] human_size Convert integer value to human readable.
-    # @return [Integer, String]
-    def size(human_size: false)
-      file_to_human_size(@file, human_size: human_size)
-    end
-
-    # @return [Symbol] {Platform}
-    def platform
-      Platform::GOOGLE
-    end
-
-    # @return [Symbol] {OperaSystem}
-    def opera_system
-      OperaSystem::ANDROID
-    end
-
-    # @return [Symbol] {Device}
-    def device
-      if watch?
-        Device::WATCH
-      elsif television?
-        Device::TELEVISION
-      elsif automotive?
-        Device::AUTOMOTIVE
-      elsif tablet?
-        Device::TABLET
-      else
-        Device::PHONE
-      end
-    end
 
     # @!method version_name
     #   @see Protobuf::Manifest#version_name
@@ -81,33 +38,6 @@ module AppInfo
     # @return [String]
     def name
       manifest.label
-    end
-
-    # @todo find a way to detect, no way!
-    # @see https://stackoverflow.com/questions/9279111/determine-if-the-device-is-a-smartphone-or-tablet
-    # @return [Boolean] false always false
-    def tablet?
-      # Not works!
-      # resource.first_package
-      #         .entries('bool')
-      #         .select{|e| e.name == 'isTablet' }
-      #         .size >= 1
-      false
-    end
-
-    # @return [Boolean]
-    def watch?
-      !!use_features&.include?('android.hardware.type.watch')
-    end
-
-    # @return [Boolean]
-    def television?
-      !!use_features&.include?('android.software.leanback')
-    end
-
-    # @return [Boolean]
-    def automotive?
-      !!use_features&.include?('android.hardware.type.automotive')
     end
 
     # @return [String]
@@ -150,27 +80,6 @@ module AppInfo
       @components ||= manifest.components.transform_values
     end
 
-    # Return multi version certifiates of signatures
-    # @return [Array<Hash>] signatures
-    # @see AppInfo::Android::Signature.verify
-    def signatures
-      @signatures ||= Android::Signature.verify(self)
-    end
-
-    # Legacy v1 scheme signatures, it will remove soon.
-    # @deprecated Use {#signatures}
-    # @return [Array<OpenSSL::PKCS7, nil>] signatures
-    def signs
-      @signs ||= v1sign&.signatures || []
-    end
-
-    # Legacy v1 scheme certificates, it will remove soon.
-    # @deprecated Use {#signatures}
-    # @return [Array<OpenSSL::PKCS7, nil>] certificates
-    def certificates
-      @certificates ||= v1sign&.certificates || []
-    end
-
     def each_file
       zip.each do |entry|
         next unless entry.file?
@@ -203,11 +112,6 @@ module AppInfo
     def resource
       io = zip.read(zip.find_entry(BASE_RESOURCES))
       @resource ||= Protobuf::Resources.parse(io)
-    end
-
-    # @return [Zip::File]
-    def zip
-      @zip ||= Zip::File.open(@file)
     end
 
     # Full icons metadata
@@ -257,18 +161,12 @@ module AppInfo
       @info = nil
     end
 
-    # @return [String] contents path of contents
-    def contents
-      @contents ||= ::File.join(Dir.mktmpdir, "AppInfo-android-#{SecureRandom.hex}")
+    # @return [Zip::File]
+    def zip
+      @zip ||= Zip::File.open(@file)
     end
 
     private
-
-    def v1sign
-      @v1sign ||= Android::Signature::V1.verify(self)
-    rescue Android::Signature::NotFoundError
-      nil
-    end
 
     def xml_file?(file)
       ::File.extname(file) == '.xml'

--- a/lib/app_info/aab.rb
+++ b/lib/app_info/aab.rb
@@ -38,11 +38,6 @@ module AppInfo
       file_to_human_size(@file, human_size: human_size)
     end
 
-    # @return [Symbol] {Format::AAB}
-    def file_type
-      Format::AAB
-    end
-
     # @return [String] {Platform::ANDROID}
     def platform
       Platform::ANDROID

--- a/lib/app_info/aab.rb
+++ b/lib/app_info/aab.rb
@@ -12,15 +12,6 @@ module AppInfo
 
     attr_reader :file
 
-    # APK Devices
-    module Device
-      PHONE       = 'Phone'
-      TABLET      = 'Tablet'
-      WATCH       = 'Watch'
-      TV          = 'Television'
-      AUTOMOTIVE  = 'Automotive'
-    end
-
     BASE_PATH = 'base'
     BASE_MANIFEST = "#{BASE_PATH}/manifest/AndroidManifest.xml"
     BASE_RESOURCES = "#{BASE_PATH}/resources.pb"
@@ -38,11 +29,37 @@ module AppInfo
       file_to_human_size(@file, human_size: human_size)
     end
 
-    # @return [String] {Platform::ANDROID}
+    # @return [Symbol] {Platform}
     def platform
-      Platform::ANDROID
+      Platform::GOOGLE
     end
 
+    # @return [Symbol] {OperaSystem}
+    def opera_system
+      OperaSystem::ANDROID
+    end
+
+    # @return [Symbol] {Device}
+    def device
+      if watch?
+        Device::WATCH
+      elsif television?
+        Device::TELEVISION
+      elsif automotive?
+        Device::AUTOMOTIVE
+      elsif tablet?
+        Device::TABLET
+      else
+        Device::PHONE
+      end
+    end
+
+    # @!method version_name
+    #   @see Protobuf::Manifest#version_name
+    # @!method deep_links
+    #   @see Protobuf::Manifest#deep_links
+    # @!method schemes
+    #   @see Protobuf::Manifest#schemes
     def_delegators :manifest, :version_name, :deep_links, :schemes
 
     alias release_version version_name
@@ -65,35 +82,24 @@ module AppInfo
       manifest.label
     end
 
-    # @return [String] {Device}
-    def device_type
-      if wear?
-        Device::WATCH
-      elsif tv?
-        Device::TV
-      elsif automotive?
-        Device::AUTOMOTIVE
-      else
-        Device::PHONE
-      end
+    # @todo find a way to detect, no way!
+    # @see https://stackoverflow.com/questions/9279111/determine-if-the-device-is-a-smartphone-or-tablet
+    def tablet?
+      # Not works!
+      # resource.first_package
+      #         .entries('bool')
+      #         .select{|e| e.name == 'isTablet' }
+      #         .size >= 1
+      false
     end
 
-    # TODO: find a way to detect
-    # Found answer but not works: https://stackoverflow.com/questions/9279111/determine-if-the-device-is-a-smartphone-or-tablet
-    # def tablet?
-    #   resource.first_package
-    #           .entries('bool')
-    #           .select{|e| e.name == 'isTablet' }
-    #           .size >= 1
-    # end
-
     # @return [Boolean]
-    def wear?
+    def watch?
       !!use_features&.include?('android.hardware.type.watch')
     end
 
     # @return [Boolean]
-    def tv?
+    def television?
       !!use_features&.include?('android.software.leanback')
     end
 

--- a/lib/app_info/aab.rb
+++ b/lib/app_info/aab.rb
@@ -56,10 +56,13 @@ module AppInfo
 
     # @!method version_name
     #   @see Protobuf::Manifest#version_name
+    #   @return [String]
     # @!method deep_links
     #   @see Protobuf::Manifest#deep_links
+    #   @return [String]
     # @!method schemes
     #   @see Protobuf::Manifest#schemes
+    #   @return [String]
     def_delegators :manifest, :version_name, :deep_links, :schemes
 
     alias release_version version_name
@@ -84,6 +87,7 @@ module AppInfo
 
     # @todo find a way to detect, no way!
     # @see https://stackoverflow.com/questions/9279111/determine-if-the-device-is-a-smartphone-or-tablet
+    # @return [Boolean] false always false
     def tablet?
       # Not works!
       # resource.first_package
@@ -133,14 +137,17 @@ module AppInfo
       @use_permissions ||= manifest&.uses_permission&.map(&:name)
     end
 
+    # @return [Protobuf::Node]
     def activities
       @activities ||= manifest.activities
     end
 
+    # @return [Protobuf::Node]
     def services
       @services ||= manifest.services
     end
 
+    # @return [Protobuf::Node]
     def components
       @components ||= manifest.components.transform_values
     end
@@ -188,6 +195,7 @@ module AppInfo
       entry
     end
 
+    # @return [Protobuf::Manifest]
     def manifest
       io = zip.read(zip.find_entry(BASE_MANIFEST))
       @manifest ||= Protobuf::Manifest.parse(io, resource)
@@ -204,7 +212,22 @@ module AppInfo
       @zip ||= Zip::File.open(@file)
     end
 
-    # @return [Array<Hash>]
+    # Full icons metadata
+    # @example
+    #   aab.icons
+    #   # => [
+    #   #   {
+    #   #     name: 'icon.png',
+    #   #     file: '/path/to/icon.png',
+    #   #     dimensions: [29, 29]
+    #   #   },
+    #   #   {
+    #   #     name: 'icon1.png',
+    #   #     file: '/path/to/icon1.png',
+    #   #     dimensions: [120, 120]
+    #   #   }
+    #   # ]
+    # @return [Array<Hash{Symbol => String, Array<Integer>}>] icons paths of icons
     def icons
       @icons ||= manifest.icons.each_with_object([]) do |res, obj|
         path = res.value
@@ -236,6 +259,7 @@ module AppInfo
       @info = nil
     end
 
+    # @return [String] contents path of contents
     def contents
       @contents ||= ::File.join(Dir.mktmpdir, "AppInfo-android-#{SecureRandom.hex}")
     end

--- a/lib/app_info/android.rb
+++ b/lib/app_info/android.rb
@@ -1,0 +1,162 @@
+# frozen_string_literal: true
+
+require 'app_info/android/signature'
+require 'image_size'
+require 'forwardable'
+
+module AppInfo
+  # Android base parser for apk and aab file
+  class Android < File
+    extend Forwardable
+    include Helper::HumanFileSize
+
+    # return file size
+    # @example Read file size in integer
+    #   aab.size                    # => 3618865
+    #
+    # @example Read file size in human readabale
+    #   aab.size(human_size: true)  # => '3.45 MB'
+    #
+    # @param [Boolean] human_size Convert integer value to human readable.
+    # @return [Integer, String]
+    def size(human_size: false)
+      file_to_human_size(@file, human_size: human_size)
+    end
+
+    # @return [Symbol] {Platform}
+    def platform
+      Platform::GOOGLE
+    end
+
+    # @return [Symbol] {OperaSystem}
+    def opera_system
+      OperaSystem::ANDROID
+    end
+
+    # @return [Symbol] {Device}
+    def device
+      if watch?
+        Device::WATCH
+      elsif television?
+        Device::TELEVISION
+      elsif automotive?
+        Device::AUTOMOTIVE
+      elsif tablet?
+        Device::TABLET
+      else
+        Device::PHONE
+      end
+    end
+
+    # @abstract Subclass and override {#name} to implement.
+    def name
+      not_implemented_error!(__method__)
+    end
+
+    # @todo find a way to detect, no way!
+    # @see https://stackoverflow.com/questions/9279111/determine-if-the-device-is-a-smartphone-or-tablet
+    # @return [Boolean] false always false
+    def tablet?
+      # Not works!
+      # resource.first_package
+      #         .entries('bool')
+      #         .select{|e| e.name == 'isTablet' }
+      #         .size >= 1
+      false
+    end
+
+    # @return [Boolean]
+    def watch?
+      !!use_features&.include?('android.hardware.type.watch')
+    end
+
+    # @return [Boolean]
+    def television?
+      !!use_features&.include?('android.software.leanback')
+    end
+
+    # @return [Boolean]
+    def automotive?
+      !!use_features&.include?('android.hardware.type.automotive')
+    end
+
+    # @abstract Subclass and override {#use_features} to implement.
+    def use_features
+      not_implemented_error!(__method__)
+    end
+
+    # @abstract Subclass and override {#use_permissions} to implement.
+    def use_permissions
+      not_implemented_error!(__method__)
+    end
+
+    # @abstract Subclass and override {#use_permissions} to implement.
+    def activities
+      not_implemented_error!(__method__)
+    end
+
+    # @abstract Subclass and override {#use_permissions} to implement.
+    def services
+      not_implemented_error!(__method__)
+    end
+
+    # @abstract Subclass and override {#use_permissions} to implement.
+    def components
+      not_implemented_error!(__method__)
+    end
+
+    # Return multi version certifiates of signatures
+    # @return [Array<Hash>] signatures
+    # @see AppInfo::Android::Signature.verify
+    def signatures
+      @signatures ||= Android::Signature.verify(self)
+    end
+
+    # Legacy v1 scheme signatures, it will remove soon.
+    # @deprecated Use {#signatures}
+    # @return [Array<OpenSSL::PKCS7, nil>] signatures
+    def signs
+      @signs ||= v1sign&.signatures || []
+    end
+
+    # Legacy v1 scheme certificates, it will remove soon.
+    # @deprecated Use {#signatures}
+    # @return [Array<OpenSSL::PKCS7, nil>] certificates
+    def certificates
+      @certificates ||= v1sign&.certificates || []
+    end
+
+    # @abstract Subclass and override {#manifest} to implement.
+    def manifest
+      not_implemented_error!(__method__)
+    end
+
+    # @abstract Subclass and override {#resource} to implement.
+    def resource
+      not_implemented_error!(__method__)
+    end
+
+    # @abstract Subclass and override {#zip} to implement.
+    def zip
+      not_implemented_error!(__method__)
+    end
+
+    # @abstract Subclass and override {#clear!} to implement.
+    def clear!
+      not_implemented_error!(__method__)
+    end
+
+    # @return [String] contents path of contents
+    def contents
+      @contents ||= ::File.join(Dir.mktmpdir, "AppInfo-android-#{SecureRandom.hex}")
+    end
+
+    protected
+
+    def v1sign
+      @v1sign ||= Android::Signature::V1.verify(self)
+    rescue Android::Signature::NotFoundError
+      nil
+    end
+  end
+end

--- a/lib/app_info/android/signature.rb
+++ b/lib/app_info/android/signature.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module AppInfo
-  module Android
+  class Android < File
     # Android Signature
     #
     # Support digest and length:
@@ -15,10 +15,10 @@ module AppInfo
       class NotFoundError < NotFoundError; end
 
       module Version
-        V1    = 1
-        V2    = 2
-        V3    = 3
-        V4    = 4
+        V1 = 1
+        V2 = 2
+        V3 = 3
+        V4 = 4
       end
 
       # All registerd verions to verify

--- a/lib/app_info/android/signatures/base.rb
+++ b/lib/app_info/android/signatures/base.rb
@@ -2,43 +2,47 @@
 
 require 'app_info/android/signatures/info'
 
-module AppInfo::Android::Signature
-  class Base
-    def self.verify(parser)
-      instance = new(parser)
-      instance.verify
-      instance
-    end
+module AppInfo
+  class Android < File
+    module Signature
+      class Base
+        def self.verify(parser)
+          instance = new(parser)
+          instance.verify
+          instance
+        end
 
-    DESCRIPTION = 'APK Signature Scheme'
+        DESCRIPTION = 'APK Signature Scheme'
 
-    attr_reader :verified
+        attr_reader :verified
 
-    def initialize(parser)
-      @parser = parser
-      @verified = false
-    end
+        def initialize(parser)
+          @parser = parser
+          @verified = false
+        end
 
-    # @abstract Subclass and override {#verify} to implement
-    def verify
-      raise NotImplementedError, ".#{__method__} method implantation required in #{self.class}"
-    end
+        # @abstract Subclass and override {#verify} to implement
+        def verify
+          raise NotImplementedError, ".#{__method__} method implantation required in #{self.class}"
+        end
 
-    # @abstract Subclass and override {#certificates} to implement
-    def certificates
-      raise NotImplementedError, ".#{__method__} method implantation required in #{self.class}"
-    end
+        # @abstract Subclass and override {#certificates} to implement
+        def certificates
+          raise NotImplementedError, ".#{__method__} method implantation required in #{self.class}"
+        end
 
-    def scheme
-      "v#{version}"
-    end
+        def scheme
+          "v#{version}"
+        end
 
-    def description
-      "#{DESCRIPTION} #{scheme}"
-    end
+        def description
+          "#{DESCRIPTION} #{scheme}"
+        end
 
-    def logger
-      @parser.logger
+        def logger
+          @parser.logger
+        end
+      end
     end
   end
 end

--- a/lib/app_info/android/signatures/info.rb
+++ b/lib/app_info/android/signatures/info.rb
@@ -3,150 +3,156 @@
 require 'stringio'
 require 'openssl'
 
-module AppInfo::Android::Signature
-  # APK signature scheme signurate info
-  #
-  # FORMAT:
-  # OFFSET       DATA TYPE  DESCRIPTION
-  # * @+0  bytes uint64:    size in bytes (excluding this field)
-  # * @+8  bytes payload
-  # * @-24 bytes uint64:    size in bytes (same as the one above)
-  # * @-16 bytes uint128:   magic value
-  class Info
-    include AppInfo::Helper::IOBlock
+module AppInfo
+  class Android < File
+    module Signature
+      # APK signature scheme signurate info
+      #
+      # FORMAT:
+      # OFFSET       DATA TYPE  DESCRIPTION
+      # * @+0  bytes uint64:    size in bytes (excluding this field)
+      # * @+8  bytes payload
+      # * @-24 bytes uint64:    size in bytes (same as the one above)
+      # * @-16 bytes uint128:   magic value
+      class Info
+        include AppInfo::Helper::IOBlock
 
-    # Signature block information
-    SIG_SIZE_OF_BLOCK_SIZE = 8
-    SIG_MAGIC_BLOCK_SIZE = 16
-    SIG_BLOCK_MIN_SIZE = 32
+        # Signature block information
+        SIG_SIZE_OF_BLOCK_SIZE = 8
+        SIG_MAGIC_BLOCK_SIZE = 16
+        SIG_BLOCK_MIN_SIZE = 32
 
-    # Magic value: APK Sig Block 42
-    SIG_MAGIC = [
-      0x41, 0x50, 0x4b, 0x20, 0x53, 0x69,
-      0x67, 0x20, 0x42, 0x6c, 0x6f, 0x63,
-      0x6b, 0x20, 0x34, 0x32
-    ].freeze
+        # Magic value: APK Sig Block 42
+        SIG_MAGIC = [
+          0x41, 0x50, 0x4b, 0x20, 0x53, 0x69,
+          0x67, 0x20, 0x42, 0x6c, 0x6f, 0x63,
+          0x6b, 0x20, 0x34, 0x32
+        ].freeze
 
-    attr_reader :total_size, :pairs, :magic, :logger
+        attr_reader :total_size, :pairs, :magic, :logger
 
-    def initialize(version, parser, logger)
-      @version = version
-      @parser = parser
-      @logger = logger
+        def initialize(version, parser, logger)
+          @version = version
+          @parser = parser
+          @logger = logger
 
-      pares_signatures_pairs
-    end
-
-    # Find singers
-    #
-    # FORMAT:
-    # OFFSET       DATA TYPE  DESCRIPTION
-    # * @+0  bytes uint64:    size in bytes
-    # * @+8  bytes payload    block
-    #   * @+0  bytes uint32:    id
-    #   * @+4  bytes payload:   value
-    def signers(block_id)
-      count = 0
-      until @pairs.eof?
-        left_bytes = left_bytes_check(
-          @pairs, UINT64_SIZE, NotFoundError,
-          "Insufficient data to read size of APK Signing Block ##{count}"
-        )
-
-        pair_buf = @pairs.read(UINT64_SIZE)
-        pair_size = pair_buf.unpack1('Q')
-        if pair_size < UINT32_SIZE || pair_size > UINT32_MAX_VALUE
-          raise NotFoundError,
-                "APK Signing Block ##{count} size out of range: #{pair_size} > #{UINT32_MAX_VALUE}"
+          pares_signatures_pairs
         end
 
-        if pair_size > left_bytes
-          raise NotFoundError,
-                "APK Signing Block ##{count} size out of range: #{pair_size} > #{left_bytes}"
+        # Find singers
+        #
+        # FORMAT:
+        # OFFSET       DATA TYPE  DESCRIPTION
+        # * @+0  bytes uint64:    size in bytes
+        # * @+8  bytes payload    block
+        #   * @+0  bytes uint32:    id
+        #   * @+4  bytes payload:   value
+        def signers(block_id)
+          count = 0
+          until @pairs.eof?
+            left_bytes = left_bytes_check(
+              @pairs, UINT64_SIZE, NotFoundError,
+              "Insufficient data to read size of APK Signing Block ##{count}"
+            )
+
+            pair_buf = @pairs.read(UINT64_SIZE)
+            pair_size = pair_buf.unpack1('Q')
+            if pair_size < UINT32_SIZE || pair_size > UINT32_MAX_VALUE
+              raise NotFoundError,
+                    "APK Signing Block ##{count} size out of range: #{pair_size} > #{UINT32_MAX_VALUE}"
+            end
+
+            if pair_size > left_bytes
+              raise NotFoundError,
+                    "APK Signing Block ##{count} size out of range: #{pair_size} > #{left_bytes}"
+            end
+
+            # fetch next signer block position
+            next_pos = @pairs.pos + pair_size.to_i
+
+            id_block = @pairs.read(UINT32_SIZE)
+            id_bytes = id_block.unpack('C*')
+            if id_bytes == block_id
+              logger.debug "Signature block id v#{@version} scheme (0x#{id_block.unpack1('H*')}) found"
+              value = @pairs.read(pair_size - UINT32_SIZE)
+              return StringIO.new(value)
+            end
+
+            @pairs.seek(next_pos)
+            count += 1
+          end
+
+          block_id_hex = block_id.reverse.pack('C*').unpack1('H*')
+          raise NotFoundError, "Not found block id 0x#{block_id_hex} in APK Signing Block."
         end
 
-        # fetch next signer block position
-        next_pos = @pairs.pos + pair_size.to_i
-
-        id_block = @pairs.read(UINT32_SIZE)
-        id_bytes = id_block.unpack('C*')
-        if id_bytes == block_id
-          logger.debug "Signature block id v#{@version} scheme (0x#{id_block.unpack1('H*')}) found"
-          value = @pairs.read(pair_size - UINT32_SIZE)
-          return StringIO.new(value)
+        def zip64?
+          zip_io.zip64_file?(start_buffer)
         end
 
-        @pairs.seek(next_pos)
-        count += 1
+        def pares_signatures_pairs
+          block = signature_block
+          block.rewind
+          # get pairs size
+          @total_size = block.size - (SIG_SIZE_OF_BLOCK_SIZE + SIG_MAGIC_BLOCK_SIZE)
+
+          # get pairs block
+          @pairs = StringIO.new(block.read(@total_size))
+
+          # get magic value
+          block.seek(block.pos + SIG_SIZE_OF_BLOCK_SIZE)
+          @magic = block.read(SIG_MAGIC_BLOCK_SIZE)
+        end
+
+        def signature_block
+          @signature_block ||= lambda {
+            logger.debug "cdir_offset: #{cdir_offset}"
+
+            file_io.seek(cdir_offset - (Info::SIG_MAGIC_BLOCK_SIZE + Info::SIG_SIZE_OF_BLOCK_SIZE))
+            footer_block = file_io.read(Info::SIG_SIZE_OF_BLOCK_SIZE)
+            if footer_block.size < Info::SIG_SIZE_OF_BLOCK_SIZE
+              raise NotFoundError, "APK Signing Block size out of range: #{footer_block.size}"
+            end
+
+            footer = footer_block.unpack1('Q')
+            total_size = footer
+            offset = cdir_offset - total_size - Info::SIG_SIZE_OF_BLOCK_SIZE
+            if offset.negative?
+              raise NotFoundError, "APK Signing Block offset out of range: #{offset}"
+            end
+
+            file_io.seek(offset)
+            header = file_io.read(Info::SIG_SIZE_OF_BLOCK_SIZE).unpack1('Q')
+
+            if header != footer
+              raise NotFoundError,
+                    "APK Signing Block header and footer mismatch: #{header} != #{footer}"
+            end
+
+            io = file_io.read(total_size)
+            StringIO.new(io)
+          }.call
+        end
+
+        def cdir_offset
+          @cdir_offset ||= lambda {
+            eocd_buffer = zip_io.get_e_o_c_d(start_buffer)
+            eocd_buffer[12..16].unpack1('V')
+          }.call
+        end
+
+        def start_buffer
+          @start_buffer ||= zip_io.start_buf(file_io)
+        end
+
+        def zip_io
+          @zip_io ||= @parser.zip
+        end
+
+        def file_io
+          @file_io ||= ::File.open(@parser.file, 'rb')
+        end
       end
-
-      block_id_hex = block_id.reverse.pack('C*').unpack1('H*')
-      raise NotFoundError, "Not found block id 0x#{block_id_hex} in APK Signing Block."
-    end
-
-    def zip64?
-      zip_io.zip64_file?(start_buffer)
-    end
-
-    def pares_signatures_pairs
-      block = signature_block
-      block.rewind
-      # get pairs size
-      @total_size = block.size - (SIG_SIZE_OF_BLOCK_SIZE + SIG_MAGIC_BLOCK_SIZE)
-
-      # get pairs block
-      @pairs = StringIO.new(block.read(@total_size))
-
-      # get magic value
-      block.seek(block.pos + SIG_SIZE_OF_BLOCK_SIZE)
-      @magic = block.read(SIG_MAGIC_BLOCK_SIZE)
-    end
-
-    def signature_block
-      @signature_block ||= lambda {
-        logger.debug "cdir_offset: #{cdir_offset}"
-
-        file_io.seek(cdir_offset - (Info::SIG_MAGIC_BLOCK_SIZE + Info::SIG_SIZE_OF_BLOCK_SIZE))
-        footer_block = file_io.read(Info::SIG_SIZE_OF_BLOCK_SIZE)
-        if footer_block.size < Info::SIG_SIZE_OF_BLOCK_SIZE
-          raise NotFoundError, "APK Signing Block size out of range: #{footer_block.size}"
-        end
-
-        footer = footer_block.unpack1('Q')
-        total_size = footer
-        offset = cdir_offset - total_size - Info::SIG_SIZE_OF_BLOCK_SIZE
-        raise NotFoundError, "APK Signing Block offset out of range: #{offset}" if offset.negative?
-
-        file_io.seek(offset)
-        header = file_io.read(Info::SIG_SIZE_OF_BLOCK_SIZE).unpack1('Q')
-
-        if header != footer
-          raise NotFoundError,
-                "APK Signing Block header and footer mismatch: #{header} != #{footer}"
-        end
-
-        io = file_io.read(total_size)
-        StringIO.new(io)
-      }.call
-    end
-
-    def cdir_offset
-      @cdir_offset ||= lambda {
-        eocd_buffer = zip_io.get_e_o_c_d(start_buffer)
-        eocd_buffer[12..16].unpack1('V')
-      }.call
-    end
-
-    def start_buffer
-      @start_buffer ||= zip_io.start_buf(file_io)
-    end
-
-    def zip_io
-      @zip_io ||= @parser.zip
-    end
-
-    def file_io
-      @file_io ||= File.open(@parser.file, 'rb')
     end
   end
 end

--- a/lib/app_info/android/signatures/v1.rb
+++ b/lib/app_info/android/signatures/v1.rb
@@ -1,59 +1,63 @@
 # frozen_string_literal: true
 
-module AppInfo::Android::Signature
-  # Android v1 Signature
-  class V1 < Base
-    DESCRIPTION = 'JAR signing'
+module AppInfo
+  class Android < File
+    module Signature
+      # Android v1 Signature
+      class V1 < Base
+        DESCRIPTION = 'JAR signing'
 
-    PKCS7_HEADER = [0x30, 0x82].freeze
+        PKCS7_HEADER = [0x30, 0x82].freeze
 
-    attr_reader :certificates, :signatures
+        attr_reader :certificates, :signatures
 
-    def version
-      Version::V1
-    end
+        def version
+          Version::V1
+        end
 
-    def description
-      DESCRIPTION
-    end
+        def description
+          DESCRIPTION
+        end
 
-    def verify
-      @signatures = fetch_signatures
-      @certificates = fetch_certificates
+        def verify
+          @signatures = fetch_signatures
+          @certificates = fetch_certificates
 
-      raise NotFoundError, 'Not found certificates' if @certificates.empty?
-    end
+          raise NotFoundError, 'Not found certificates' if @certificates.empty?
+        end
 
-    private
+        private
 
-    def fetch_signatures
-      case @parser
-      when AppInfo::APK
-        signatures_from(@parser.apk)
-      when AppInfo::AAB
-        signatures_from(@parser)
+        def fetch_signatures
+          case @parser
+          when AppInfo::APK
+            signatures_from(@parser.apk)
+          when AppInfo::AAB
+            signatures_from(@parser)
+          end
+        end
+
+        def fetch_certificates
+          @signatures.each_with_object([]) do |(_, sign), obj|
+            next if sign.certificates.empty?
+
+            obj << AppInfo::Certificate.new(sign.certificates[0])
+          end
+        end
+
+        def signatures_from(parser)
+          signs = {}
+          parser.each_file do |path, data|
+            # find META-INF/xxx.{RSA|DSA|EC}
+            next unless path =~ %r{^META-INF/} && data.unpack('CC') == PKCS7_HEADER
+
+            signs[path] = OpenSSL::PKCS7.new(data)
+          end
+          signs
+        end
       end
-    end
 
-    def fetch_certificates
-      @signatures.each_with_object([]) do |(_, sign), obj|
-        next if sign.certificates.empty?
-
-        obj << AppInfo::Certificate.new(sign.certificates[0])
-      end
-    end
-
-    def signatures_from(parser)
-      signs = {}
-      parser.each_file do |path, data|
-        # find META-INF/xxx.{RSA|DSA|EC}
-        next unless path =~ %r{^META-INF/} && data.unpack('CC') == PKCS7_HEADER
-
-        signs[path] = OpenSSL::PKCS7.new(data)
-      end
-      signs
+      register(Version::V1, V1)
     end
   end
-
-  register(Version::V1, V1)
 end

--- a/lib/app_info/android/signatures/v2.rb
+++ b/lib/app_info/android/signatures/v2.rb
@@ -1,117 +1,121 @@
 # frozen_string_literal: true
 
-module AppInfo::Android::Signature
-  # Android v2 Signature
-  #
-  # FULL FORMAT:
-  # OFFSET       DATA TYPE  DESCRIPTION
-  # * @+0  bytes uint32:    signer size in bytes
-  # * @+4  bytes payload    signer block
-  #   * @+0  bytes unit32:    signed data size in bytes
-  #   * @+4  bytes payload    signed data block
-  #     * @+0  bytes unit32:    digests with size in bytes
-  #     * @+0  bytes unit32:    digests with size in bytes
-  #   * @+X  bytes unit32:    signatures with size in bytes
-  #     * @+X+4  bytes payload    signed data block
-  #   * @+Y  bytes unit32:    public key with size in bytes
-  #     * @+Y+4  bytes payload    signed data block
-  class V2 < Base
-    include AppInfo::Helper::IOBlock
-    include AppInfo::Helper::Signatures
-    include AppInfo::Helper::Algorithm
+module AppInfo
+  class Android < File
+    module Signature
+      # Android v2 Signature
+      #
+      # FULL FORMAT:
+      # OFFSET       DATA TYPE  DESCRIPTION
+      # * @+0  bytes uint32:    signer size in bytes
+      # * @+4  bytes payload    signer block
+      #   * @+0  bytes unit32:    signed data size in bytes
+      #   * @+4  bytes payload    signed data block
+      #     * @+0  bytes unit32:    digests with size in bytes
+      #     * @+0  bytes unit32:    digests with size in bytes
+      #   * @+X  bytes unit32:    signatures with size in bytes
+      #     * @+X+4  bytes payload    signed data block
+      #   * @+Y  bytes unit32:    public key with size in bytes
+      #     * @+Y+4  bytes payload    signed data block
+      class V2 < Base
+        include AppInfo::Helper::IOBlock
+        include AppInfo::Helper::Signatures
+        include AppInfo::Helper::Algorithm
 
-    # V2 Signature ID 0x7109871a
-    BLOCK_ID = [0x1a, 0x87, 0x09, 0x71].freeze
+        # V2 Signature ID 0x7109871a
+        BLOCK_ID = [0x1a, 0x87, 0x09, 0x71].freeze
 
-    attr_reader :certificates, :digests
+        attr_reader :certificates, :digests
 
-    def version
-      Version::V2
-    end
+        def version
+          Version::V2
+        end
 
-    # Verify
-    # @todo verified signatures
-    def verify
-      signers_block = singers_block(BLOCK_ID)
-      @certificates, @digests = verified_certs(signers_block, verify: true)
-      # @verified = true
-    end
+        # Verify
+        # @todo verified signatures
+        def verify
+          signers_block = singers_block(BLOCK_ID)
+          @certificates, @digests = verified_certs(signers_block, verify: true)
+          # @verified = true
+        end
 
-    private
+        private
 
-    def verified_certs(signers_block, verify:)
-      unless (signers = length_prefix_block(signers_block))
-        raise SecurityError, 'Not found signers'
+        def verified_certs(signers_block, verify:)
+          unless (signers = length_prefix_block(signers_block))
+            raise SecurityError, 'Not found signers'
+          end
+
+          certificates = []
+          content_digests = {}
+          loop_length_prefix_io(signers, name: 'Singer', logger: logger) do |signer|
+            signer_certs, signer_digests = extract_signer_data(signer, verify: verify)
+            certificates.concat(signer_certs)
+            content_digests.merge!(signer_digests)
+          end
+          raise SecurityError, 'No signers found' if certificates.empty?
+
+          [certificates, content_digests]
+        end
+
+        def extract_signer_data(signer, verify:)
+          # raw data
+          signed_data = length_prefix_block(signer)
+          signatures = length_prefix_block(signer)
+          public_key = length_prefix_block(signer, raw: true)
+
+          # FIXME: extract code below and re-organize
+
+          algorithems = signature_algorithms(signatures)
+          raise SecurityError, 'No signatures found' if verify && algorithems.empty?
+
+          # find best algorithem to verify signed data with public key and signature
+          unless best_algorithem = best_algorithem(algorithems)
+            raise SecurityError, 'No supported signatures found'
+          end
+
+          algorithems_digest = best_algorithem[:digest]
+          signature = best_algorithem[:signature]
+
+          pkey = OpenSSL::PKey.read(public_key)
+          digest = OpenSSL::Digest.new(algorithems_digest)
+          verified = pkey.verify(digest, signature, signed_data.string)
+          raise SecurityError, "#{algorithems_digest} signature did not verify" unless verified
+
+          # verify algorithm ID full equal (and sort) between digests and signature
+          digests = length_prefix_block(signed_data)
+          content_digests = signed_data_digests(digests)
+          content_digest = content_digests[algorithems_digest]&.fetch(:content)
+
+          unless content_digest
+            raise SecurityError,
+                  'Signature algorithms don\'t match between digests and signatures records'
+          end
+
+          previous_digest = content_digests.fetch(algorithems_digest)
+          content_digests[algorithems_digest] = content_digest
+          if previous_digest && previous_digest[:content] != content_digest
+            raise SecurityError,
+                  'Signature algorithms don\'t match between digests and signatures records'
+          end
+
+          certificates = length_prefix_block(signed_data)
+          certs = signed_data_certs(certificates)
+          raise SecurityError, 'No certificates listed' if certs.empty?
+
+          main_cert = certs[0]
+          if main_cert.public_key.to_der != pkey.to_der
+            raise SecurityError, 'Public key mismatch between certificate and signature record'
+          end
+
+          additional_attrs = length_prefix_block(signed_data)
+          verify_additional_attrs(additional_attrs, certs)
+
+          [certs, content_digests]
+        end
       end
 
-      certificates = []
-      content_digests = {}
-      loop_length_prefix_io(signers, name: 'Singer', logger: logger) do |signer|
-        signer_certs, signer_digests = extract_signer_data(signer, verify: verify)
-        certificates.concat(signer_certs)
-        content_digests.merge!(signer_digests)
-      end
-      raise SecurityError, 'No signers found' if certificates.empty?
-
-      [certificates, content_digests]
-    end
-
-    def extract_signer_data(signer, verify:)
-      # raw data
-      signed_data = length_prefix_block(signer)
-      signatures = length_prefix_block(signer)
-      public_key = length_prefix_block(signer, raw: true)
-
-      # FIXME: extract code below and re-organizate
-
-      algorithems = signature_algorithms(signatures)
-      raise SecurityError, 'No signatures found' if verify && algorithems.empty?
-
-      # find best algorithem to verify signed data with public key and signature
-      unless best_algorithem = best_algorithem(algorithems)
-        raise SecurityError, 'No supported signatures found'
-      end
-
-      algorithems_digest = best_algorithem[:digest]
-      signature = best_algorithem[:signature]
-
-      pkey = OpenSSL::PKey.read(public_key)
-      digest = OpenSSL::Digest.new(algorithems_digest)
-      verified = pkey.verify(digest, signature, signed_data.string)
-      raise SecurityError, "#{algorithems_digest} signature did not verify" unless verified
-
-      # verify algorithm ID full equal (and sort) between digests and signature
-      digests = length_prefix_block(signed_data)
-      content_digests = signed_data_digests(digests)
-      content_digest = content_digests[algorithems_digest]&.fetch(:content)
-
-      unless content_digest
-        raise SecurityError,
-              'Signature algorithms don\'t match between digests and signatures records'
-      end
-
-      previous_digest = content_digests.fetch(algorithems_digest)
-      content_digests[algorithems_digest] = content_digest
-      if previous_digest && previous_digest[:content] != content_digest
-        raise SecurityError,
-              'Signature algorithms don\'t match between digests and signatures records'
-      end
-
-      certificates = length_prefix_block(signed_data)
-      certs = signed_data_certs(certificates)
-      raise SecurityError, 'No certificates listed' if certs.empty?
-
-      main_cert = certs[0]
-      if main_cert.public_key.to_der != pkey.to_der
-        raise SecurityError, 'Public key mismatch between certificate and signature record'
-      end
-
-      additional_attrs = length_prefix_block(signed_data)
-      verify_additional_attrs(additional_attrs, certs)
-
-      [certs, content_digests]
+      register(Version::V2, V2)
     end
   end
-
-  register(Version::V2, V2)
 end

--- a/lib/app_info/android/signatures/v3.rb
+++ b/lib/app_info/android/signatures/v3.rb
@@ -1,127 +1,131 @@
 # frozen_string_literal: true
 
-module AppInfo::Android::Signature
-  # Android v3 Signature
-  #
-  # FULL FORMAT:
-  # OFFSET       DATA TYPE  DESCRIPTION
-  # * @+0  bytes uint32:    signer size in bytes
-  # * @+4  bytes payload    signer block
-  #   * @+0    bytes unit32:    signed data size in bytes
-  #   * @+4    bytes payload    signed data block
-  #     * @+0    bytes unit32:    digests with size in bytes
-  #     * @+0    bytes unit32:    digests with size in bytes
-  #   * @+W    bytes unit32:    minSDK
-  #   * @+X+4  bytes unit32:    maxSDK
-  #   * @+Y+4  bytes unit32:    signatures with size in bytes
-  #     * @+Y+4    bytes payload    signed data block
-  #   * @+Z    bytes unit32:    public key with size in bytes
-  #     * @+Z+4    bytes payload    signed data block
-  class V3 < Base
-    include AppInfo::Helper::IOBlock
-    include AppInfo::Helper::Signatures
-    include AppInfo::Helper::Algorithm
+module AppInfo
+  class Android < File
+    module Signature
+      # Android v3 Signature
+      #
+      # FULL FORMAT:
+      # OFFSET       DATA TYPE  DESCRIPTION
+      # * @+0  bytes uint32:    signer size in bytes
+      # * @+4  bytes payload    signer block
+      #   * @+0    bytes unit32:    signed data size in bytes
+      #   * @+4    bytes payload    signed data block
+      #     * @+0    bytes unit32:    digests with size in bytes
+      #     * @+0    bytes unit32:    digests with size in bytes
+      #   * @+W    bytes unit32:    minSDK
+      #   * @+X+4  bytes unit32:    maxSDK
+      #   * @+Y+4  bytes unit32:    signatures with size in bytes
+      #     * @+Y+4    bytes payload    signed data block
+      #   * @+Z    bytes unit32:    public key with size in bytes
+      #     * @+Z+4    bytes payload    signed data block
+      class V3 < Base
+        include AppInfo::Helper::IOBlock
+        include AppInfo::Helper::Signatures
+        include AppInfo::Helper::Algorithm
 
-    # V3 Signature ID 0xf05368c0
-    V3_BLOCK_ID   = [0xc0, 0x68, 0x53, 0xf0].freeze
+        # V3 Signature ID 0xf05368c0
+        V3_BLOCK_ID   = [0xc0, 0x68, 0x53, 0xf0].freeze
 
-    # V3.1 Signature ID 0x1b93ad61
-    V3_1_BLOCK_ID = [0x61, 0xad, 0x93, 0x1b].freeze
+        # V3.1 Signature ID 0x1b93ad61
+        V3_1_BLOCK_ID = [0x61, 0xad, 0x93, 0x1b].freeze
 
-    attr_reader :certificates, :digests
+        attr_reader :certificates, :digests
 
-    def version
-      Version::V3
-    end
+        def version
+          Version::V3
+        end
 
-    def verify
-      begin
-        signers_block = singers_block(V3_1_BLOCK_ID)
-      rescue NotFoundError
-        signers_block = singers_block(V3_BLOCK_ID)
+        def verify
+          begin
+            signers_block = singers_block(V3_1_BLOCK_ID)
+          rescue NotFoundError
+            signers_block = singers_block(V3_BLOCK_ID)
+          end
+
+          @certificates, @digests = verified_certs(signers_block)
+        end
+
+        private
+
+        def verified_certs(signers_block)
+          unless (signers = length_prefix_block(signers_block))
+            raise SecurityError, 'Not found signers'
+          end
+
+          certificates = []
+          content_digests = {}
+          loop_length_prefix_io(signers, name: 'Singer', logger: logger) do |signer|
+            signer_certs, signer_digests = extract_signer_data(signer)
+            certificates.concat(signer_certs)
+            content_digests.merge!(signer_digests)
+          end
+          raise SecurityError, 'No signers found' if certificates.empty?
+
+          [certificates, content_digests]
+        end
+
+        def extract_signer_data(signer)
+          # raw data
+          signed_data = length_prefix_block(signer)
+
+          # TODO: verify min_sdk and max_sdk
+          min_sdk = signer.read(UINT32_SIZE)
+          max_sdk = signer.read(UINT32_SIZE)
+
+          signatures = length_prefix_block(signer)
+          public_key = length_prefix_block(signer, raw: true)
+
+          algorithems = signature_algorithms(signatures)
+          raise SecurityError, 'No signatures found' if algorithems.empty?
+
+          # find best algorithem to verify signed data with public key and signature
+          unless best_algorithem = best_algorithem(algorithems)
+            raise SecurityError, 'No supported signatures found'
+          end
+
+          algorithems_digest = best_algorithem[:digest]
+          signature = best_algorithem[:signature]
+
+          pkey = OpenSSL::PKey.read(public_key)
+          digest = OpenSSL::Digest.new(algorithems_digest)
+          verified = pkey.verify(digest, signature, signed_data.string)
+          raise SecurityError, "#{algorithems_digest} signature did not verify" unless verified
+
+          # verify algorithm ID full equal (and sort) between digests and signature
+          digests = length_prefix_block(signed_data)
+          content_digests = signed_data_digests(digests)
+          content_digest = content_digests[algorithems_digest]&.fetch(:content)
+
+          unless content_digest
+            raise SecurityError,
+                  'Signature algorithms don\'t match between digests and signatures records'
+          end
+
+          previous_digest = content_digests.fetch(algorithems_digest)
+          content_digests[algorithems_digest] = content_digest
+          if previous_digest && previous_digest[:content] != content_digest
+            raise SecurityError,
+                  'Signature algorithms don\'t match between digests and signatures records'
+          end
+
+          certificates = length_prefix_block(signed_data)
+          certs = signed_data_certs(certificates)
+          raise SecurityError, 'No certificates listed' if certs.empty?
+
+          main_cert = certs[0]
+          if main_cert.public_key.to_der != pkey.to_der
+            raise SecurityError, 'Public key mismatch between certificate and signature record'
+          end
+
+          additional_attrs = length_prefix_block(signed_data)
+          verify_additional_attrs(additional_attrs, certs)
+
+          [certs, content_digests]
+        end
       end
 
-      @certificates, @digests = verified_certs(signers_block)
-    end
-
-    private
-
-    def verified_certs(signers_block)
-      unless (signers = length_prefix_block(signers_block))
-        raise SecurityError, 'Not found signers'
-      end
-
-      certificates = []
-      content_digests = {}
-      loop_length_prefix_io(signers, name: 'Singer', logger: logger) do |signer|
-        signer_certs, signer_digests = extract_signer_data(signer)
-        certificates.concat(signer_certs)
-        content_digests.merge!(signer_digests)
-      end
-      raise SecurityError, 'No signers found' if certificates.empty?
-
-      [certificates, content_digests]
-    end
-
-    def extract_signer_data(signer)
-      # raw data
-      signed_data = length_prefix_block(signer)
-
-      # TODO: verify min_sdk and max_sdk
-      min_sdk = signer.read(UINT32_SIZE)
-      max_sdk = signer.read(UINT32_SIZE)
-
-      signatures = length_prefix_block(signer)
-      public_key = length_prefix_block(signer, raw: true)
-
-      algorithems = signature_algorithms(signatures)
-      raise SecurityError, 'No signatures found' if algorithems.empty?
-
-      # find best algorithem to verify signed data with public key and signature
-      unless best_algorithem = best_algorithem(algorithems)
-        raise SecurityError, 'No supported signatures found'
-      end
-
-      algorithems_digest = best_algorithem[:digest]
-      signature = best_algorithem[:signature]
-
-      pkey = OpenSSL::PKey.read(public_key)
-      digest = OpenSSL::Digest.new(algorithems_digest)
-      verified = pkey.verify(digest, signature, signed_data.string)
-      raise SecurityError, "#{algorithems_digest} signature did not verify" unless verified
-
-      # verify algorithm ID full equal (and sort) between digests and signature
-      digests = length_prefix_block(signed_data)
-      content_digests = signed_data_digests(digests)
-      content_digest = content_digests[algorithems_digest]&.fetch(:content)
-
-      unless content_digest
-        raise SecurityError,
-              'Signature algorithms don\'t match between digests and signatures records'
-      end
-
-      previous_digest = content_digests.fetch(algorithems_digest)
-      content_digests[algorithems_digest] = content_digest
-      if previous_digest && previous_digest[:content] != content_digest
-        raise SecurityError,
-              'Signature algorithms don\'t match between digests and signatures records'
-      end
-
-      certificates = length_prefix_block(signed_data)
-      certs = signed_data_certs(certificates)
-      raise SecurityError, 'No certificates listed' if certs.empty?
-
-      main_cert = certs[0]
-      if main_cert.public_key.to_der != pkey.to_der
-        raise SecurityError, 'Public key mismatch between certificate and signature record'
-      end
-
-      additional_attrs = length_prefix_block(signed_data)
-      verify_additional_attrs(additional_attrs, certs)
-
-      [certs, content_digests]
+      register(Version::V3, V3)
     end
   end
-
-  register(Version::V3, V3)
 end

--- a/lib/app_info/android/signatures/v4.rb
+++ b/lib/app_info/android/signatures/v4.rb
@@ -1,14 +1,18 @@
 # frozen_string_literal: true
 
-module AppInfo::Android::Signature
-  # Android v4 Signature
-  #
-  # TODO: ApkSignatureSchemeV4Verifier.java
-  class V4 < Base
-    def version
-      Version::V4
+module AppInfo
+  class Android < File
+    module Signature
+      # Android v4 Signature
+      #
+      # TODO: ApkSignatureSchemeV4Verifier.java
+      class V4 < Base
+        def version
+          Version::V4
+        end
+      end
+
+      # register(Version::V4, V4)
     end
   end
-
-  # register(Version::V4, V4)
 end

--- a/lib/app_info/apk.rb
+++ b/lib/app_info/apk.rb
@@ -104,18 +104,22 @@ module AppInfo
       false
     end
 
+    # @return [Boolean]
     def watch?
       use_features.include?('android.hardware.type.watch')
     end
 
+    # @return [Boolean]
     def television?
       use_features.include?('android.software.leanback')
     end
 
+    # @return [Boolean]
     def automotive?
       use_features.include?('android.hardware.type.automotive')
     end
 
+    # @return [String]
     def min_sdk_version
       manifest.min_sdk_ver
     end
@@ -142,18 +146,37 @@ module AppInfo
       @certificates ||= v1sign&.certificates || []
     end
 
+    # @return [String]
     def activities
       components.select { |c| c.type == 'activity' }
     end
 
+    # @return [::Android::Apk]
     def apk
       @apk ||= ::Android::Apk.new(@file)
     end
 
+    # @return [Zip::File]
     def zip
       @zip ||= apk.instance_variable_get(:@zip)
     end
 
+    # Full icons metadata
+    # @example
+    #   apk.icons
+    #   # => [
+    #   #   {
+    #   #     name: 'icon.png',
+    #   #     file: '/path/to/icon.png',
+    #   #     dimensions: [29, 29]
+    #   #   },
+    #   #   {
+    #   #     name: 'icon1.png',
+    #   #     file: '/path/to/icon1.png',
+    #   #     dimensions: [120, 120]
+    #   #   }
+    #   # ]
+    # @return [Array<Hash{Symbol => String, Array<Integer>}>] icons paths of icons
     def icons
       @icons ||= apk.icon.each_with_object([]) do |(path, data), obj|
         icon_name = ::File.basename(path)
@@ -182,6 +205,7 @@ module AppInfo
       @info = nil
     end
 
+    # @return [String] contents path of contents
     def contents
       @contents ||= ::File.join(Dir.mktmpdir, "AppInfo-android-#{SecureRandom.hex}")
     end

--- a/lib/app_info/apk.rb
+++ b/lib/app_info/apk.rb
@@ -34,10 +34,6 @@ module AppInfo
       file_to_human_size(@file, human_size: human_size)
     end
 
-    def file_type
-      Format::APK
-    end
-
     def platform
       Platform::ANDROID
     end

--- a/lib/app_info/apk.rb
+++ b/lib/app_info/apk.rb
@@ -12,15 +12,6 @@ module AppInfo
 
     attr_reader :file
 
-    # APK Devices
-    module Device
-      PHONE       = 'Phone'
-      TABLET      = 'Tablet'
-      WATCH       = 'Watch'
-      TV          = 'Television'
-      AUTOMOTIVE  = 'Automotive'
-    end
-
     # return file size
     # @example Read file size in integer
     #   aab.size                    # => 3618865
@@ -34,12 +25,57 @@ module AppInfo
       file_to_human_size(@file, human_size: human_size)
     end
 
+    # @return [Symbol] {Platform}
     def platform
-      Platform::ANDROID
+      Platform::GOOGLE
     end
 
+    # @return [Symbol] {OperaSystem}
+    def opera_system
+      OperaSystem::ANDROID
+    end
+
+    # @return [Symbol] {Device}
+    def device
+      if watch?
+        Device::WATCH
+      elsif television?
+        Device::TELEVISION
+      elsif automotive?
+        Device::AUTOMOTIVE
+      elsif tablet?
+        Device::TABLET
+      else
+        Device::PHONE
+      end
+    end
+
+    # @!method manifest
+    #   @see https://rubydoc.info/gems/android_parser/Android/Apk#manifest-instance_method ::Android::Apk#manifest
+    # @!method resource
+    #   @see https://rubydoc.info/gems/android_parser/Android/Apk#resource-instance_method ::Android::Apk#resource
+    # @!method dex
+    #   @see https://rubydoc.info/gems/android_parser/Android/Apk#dex-instance_method ::Android::Apk#dex
     def_delegators :apk, :manifest, :resource, :dex
 
+    # @!method version_name
+    #   @see https://rubydoc.info/gems/android_parser/Android/Manifest#version_name-instance_method  ::Android::Manifest#version_name
+    # @!method package_name
+    #   @see https://rubydoc.info/gems/android_parser/Android/Manifest#package_name-instance_method  ::Android::Manifest#package_name
+    # @!method target_sdk_versionx
+    #   @see https://rubydoc.info/gems/android_parser/Android/Manifest#target_sdk_versionx-instance_method  ::Android::Manifest#target_sdk_version
+    # @!method components
+    #   @see https://rubydoc.info/gems/android_parser/Android/Manifest#components-instance_method  ::Android::Manifest#components
+    # @!method services
+    #   @see https://rubydoc.info/gems/android_parser/Android/Manifest#services-instance_method  ::Android::Manifest#services
+    # @!method use_permissions
+    #   @see https://rubydoc.info/gems/android_parser/Android/Manifest#use_permissions-instance_method  ::Android::Manifest#use_permissions
+    # @!method use_features
+    #   @see https://rubydoc.info/gems/android_parser/Android/Manifest#use_features-instance_method  ::Android::Manifest#use_features
+    # @!method deep_links
+    #   @see https://rubydoc.info/gems/android_parser/Android/Manifest#deep_links-instance_method ::Android::Manifest#deep_links
+    # @!method schemes
+    #   @see https://rubydoc.info/gems/android_parser/Android/Manifest#schemes-instance_method ::Android::Manifest#schemes
     def_delegators :manifest, :version_name, :package_name, :target_sdk_version,
                    :components, :services, :use_permissions, :use_features,
                    :deep_links, :schemes
@@ -57,27 +93,22 @@ module AppInfo
       manifest.label || resource.find('@string/app_name')
     end
 
-    def device_type
-      if wear?
-        Device::WATCH
-      elsif tv?
-        Device::TV
-      elsif automotive?
-        Device::AUTOMOTIVE
-      else
-        Device::PHONE
-      end
+    # @todo find a way to detect, no way!
+    # @see https://stackoverflow.com/questions/9279111/determine-if-the-device-is-a-smartphone-or-tablet
+    def tablet?
+      # Not works!
+      # resource.first_package
+      #         .entries('bool')
+      #         .select{|e| e.name == 'isTablet' }
+      #         .size >= 1
+      false
     end
 
-    # TODO: find a way to detect, no way!
-    # def tablet?
-    # end
-
-    def wear?
+    def watch?
       use_features.include?('android.hardware.type.watch')
     end
 
-    def tv?
+    def television?
       use_features.include?('android.software.leanback')
     end
 

--- a/lib/app_info/apk.rb
+++ b/lib/app_info/apk.rb
@@ -10,8 +10,6 @@ module AppInfo
     include Helper::HumanFileSize
     extend Forwardable
 
-    attr_reader :file
-
     # return file size
     # @example Read file size in integer
     #   aab.size                    # => 3618865

--- a/lib/app_info/apple.rb
+++ b/lib/app_info/apple.rb
@@ -1,0 +1,192 @@
+# frozen_string_literal: true
+
+require 'macho'
+require 'fileutils'
+require 'forwardable'
+require 'cfpropertylist'
+
+module AppInfo
+  # Apple base parser for ipa and macos file
+  class Apple < File
+    extend Forwardable
+    include Helper::HumanFileSize
+    include Helper::Archive
+
+    # Export types
+    module ExportType
+      # debug configuration
+      DEBUG = :debug
+      # adhoc configuration (iOS only)
+      ADHOC = :adhoc
+      # enterprise configuration (iOS only)
+      ENTERPRISE = :enterprise
+      # release configuration
+      RELEASE = :release
+      # release configuration but download from App Store
+      APPSTORE = :appstore
+    end
+
+    # @return [Symbol] {Platform}
+    def platform
+      Platform::APPLE
+    end
+
+    # return file size
+    # @example Read file size in integer
+    #   aab.size                    # => 3618865
+    #
+    # @example Read file size in human readabale
+    #   aab.size(human_size: true)  # => '3.45 MB'
+    #
+    # @param [Boolean] human_size Convert integer value to human readable.
+    # @return [Integer, String]
+    def size(human_size: false)
+      file_to_human_size(@file, human_size: human_size)
+    end
+
+    # @!method device
+    #   @see InfoPlist#device
+    # @!method opera_system
+    #   @see InfoPlist#opera_system
+    # @!method iphone?
+    #   @see InfoPlist#iphone?
+    # @!method ipad?
+    #   @see InfoPlist#ipad?
+    # @!method universal?
+    #   @see InfoPlist#universal?
+    # @!method build_version
+    #   @see InfoPlist#build_version
+    # @!method name
+    #   @see InfoPlist#name
+    # @!method release_version
+    #   @see InfoPlist#release_version
+    # @!method identifier
+    #   @see InfoPlist#identifier
+    # @!method bundle_id
+    #   @see InfoPlist#bundle_id
+    # @!method display_name
+    #   @see InfoPlist#display_name
+    # @!method bundle_name
+    #   @see InfoPlist#bundle_name
+    # @!method min_sdk_version
+    #   @see InfoPlist#min_sdk_version
+    # @!method min_os_version
+    #   @see InfoPlist#min_os_version
+    def_delegators :info, :device, :opera_system, :iphone?, :ipad?, :universal?, :macos?,
+                   :build_version, :name, :release_version, :identifier, :bundle_id,
+                   :display_name, :bundle_name, :min_sdk_version, :min_os_version
+
+    # @!method devices
+    #   @see MobileProvision#devices
+    # @!method team_name
+    #   @see MobileProvision#team_name
+    # @!method team_identifier
+    #   @see MobileProvision#team_identifier
+    # @!method profile_name
+    #   @see MobileProvision#profile_name
+    # @!method expired_date
+    #   @see MobileProvision#expired_date
+    def_delegators :mobileprovision, :devices, :team_name, :team_identifier,
+                   :profile_name, :expired_date
+
+    # @return [String, nil]
+    def distribution_name
+      "#{profile_name} - #{team_name}" if profile_name && team_name
+    end
+
+    # @return [String]
+    def release_type
+      if stored?
+        ExportType::APPSTORE
+      else
+        build_type
+      end
+    end
+
+    # return iOS build configuration, not correct in macOS app.
+    # @return [String]
+    def build_type
+      if mobileprovision?
+        return ExportType::RELEASE if macos?
+
+        devices ? ExportType::ADHOC : ExportType::ENTERPRISE
+      else
+        ExportType::DEBUG
+      end
+    end
+
+    # @return [Array<MachO>, nil]
+    def archs
+      return unless ::File.exist?(binary_path)
+
+      file = MachO.open(binary_path)
+      case file
+      when MachO::MachOFile
+        [file.cpusubtype]
+      else
+        file.machos.each_with_object([]) do |arch, obj|
+          obj << arch.cpusubtype
+        end
+      end
+    end
+    alias architectures archs
+
+    # @abstract Subclass and override {#icons} to implement.
+    def icons(_uncrush: true)
+      not_implemented_error!(__method__)
+    end
+
+    # @abstract Subclass and override {#stored?} to implement.
+    def stored?
+      not_implemented_error!(__method__)
+    end
+
+    # force remove developer certificate data from {#mobileprovision} method
+    # @return [nil]
+    def hide_developer_certificates
+      mobileprovision.delete('DeveloperCertificates') if mobileprovision?
+    end
+
+    # @return [MobileProvision]
+    def mobileprovision
+      return unless mobileprovision?
+
+      @mobileprovision ||= MobileProvision.new(mobileprovision_path)
+    end
+
+    # @return [Boolean]
+    def mobileprovision?
+      ::File.exist?(mobileprovision_path)
+    end
+
+    # @abstract Subclass and override {#mobileprovision_path} to implement.
+    def mobileprovision_path
+      not_implemented_error!(__method__)
+    end
+
+    # @return [InfoPlist]
+    def info
+      @info ||= InfoPlist.new(info_path)
+    end
+
+    # @abstract Subclass and override {#info_path} to implement.
+    def info_path
+      not_implemented_error!(__method__)
+    end
+
+    # @abstract Subclass and override {#app_path} to implement.
+    def app_path
+      not_implemented_error!(__method__)
+    end
+
+    # @abstract Subclass and override {#clear!} to implement.
+    def clear!
+      not_implemented_error!(__method__)
+    end
+
+    # @return [String] contents path of contents
+    def contents
+      @contents ||= unarchive(@file, prefix: format.to_s)
+    end
+  end
+end

--- a/lib/app_info/certificate.rb
+++ b/lib/app_info/certificate.rb
@@ -54,18 +54,22 @@ module AppInfo
       convert_cert_name(raw.subject, format: format)
     end
 
+    # @return [Time]
     def created_at
       raw.not_before
     end
 
+    # @return [Time]
     def expired_at
       raw.not_after
     end
 
+    # @return [Boolean]
     def expired?
       expired_at < Time.now.utc
     end
 
+    # @return [String] format always be :x509.
     def format
       :x509
     end
@@ -114,6 +118,7 @@ module AppInfo
     end
 
     # return size of public key
+    # @return [Integer]
     def size
       case public_key
       when OpenSSL::PKey::RSA
@@ -126,23 +131,9 @@ module AppInfo
     end
 
     # return fingerprint of certificate
+    # @return [String]
     def fingerprint(name = :sha256, transform: :lower, delimiter: nil)
       digest = OpenSSL::Digest.new(name.to_s.upcase)
-      # digest = case name.to_sym
-      #          when :sha1
-      #            OpenSSL::Digest::SHA1.new
-      #          when :sha224
-      #            OpenSSL::Digest::SHA224.new
-      #          when :sha384
-      #            OpenSSL::Digest::SHA384.new
-      #          when :sha512
-      #            OpenSSL::Digest::SHA512.new
-      #          when :md5
-      #            OpenSSL::Digest::MD5.new
-      #          else
-      #            OpenSSL::Digest::SHA256.new
-      #          end
-
       digest.update(raw.to_der)
       fingerprint = digest.to_s
       fingerprint = fingerprint.upcase if transform.to_sym == :upper
@@ -152,6 +143,7 @@ module AppInfo
     end
 
     # Orginal OpenSSL X509 certificate
+    # @return [OpenSSL::X509::Certificate]
     def raw
       @cert
     end

--- a/lib/app_info/certificate.rb
+++ b/lib/app_info/certificate.rb
@@ -174,8 +174,10 @@ module AppInfo
       @cert.send(method.to_sym, *args, &block) || super
     end
 
-    def respond_to_missing?(method, *args)
-      @cert.include?(method.to_sym) || super
+    def respond_to_missing?(method_name, *args)
+      @cert.key?(method_name.to_sym) ||
+        @cert.respond_to?(method_name) ||
+        super
     end
   end
 end

--- a/lib/app_info/const.rb
+++ b/lib/app_info/const.rb
@@ -3,21 +3,28 @@
 module AppInfo
   # Full Format
   module Format
-    # iOS
-    IPA = :ipa
+    # Apple
+
     INFOPLIST = :infoplist
     MOBILEPROVISION = :mobileprovision
     DSYM = :dsym
 
+    # macOS
+
+    MACOS = :macos
+
+    # iOS
+
+    IPA = :ipa
+
     # Android
+
     APK = :apk
     AAB = :aab
     PROGUARD = :proguard
 
-    # macOS
-    MACOS = :macos
-
     # Windows
+
     PE = :pe
 
     UNKNOWN = :unknown
@@ -25,17 +32,44 @@ module AppInfo
 
   # Platform
   module Platform
-    WINDOWS = 'Windows'
-    MACOS = 'macOS'
-    IOS = 'iOS'
-    ANDROID = 'Android'
+    APPLE = :apple
+    GOOGLE = :google
+    WINDOWS = :windows
+  end
+
+  module OperaSystem
+    MACOS = :macos
+    IOS = :ios
+    ANDROID = :android
+    WINDOWS = :windows
   end
 
   # Apple Device Type
   module Device
-    MACOS = 'macOS'
-    IPHONE = 'iPhone'
-    IPAD = 'iPad'
-    UNIVERSAL = 'Universal'
+    # macOS
+    MACOS = :macos
+
+    # Apple iPhone
+    IPHONE = :iphone
+    # Apple iPad
+    IPAD = :ipad
+    # Apple Watch
+    IWATCH = :iwatch # not implemented yet
+    # Apple Universal (iPhone and iPad)
+    UNIVERSAL = :universal
+
+    # Android Phone
+    PHONE = :phone
+    # Android Tablet (not implemented yet)
+    TABLET = :tablet
+    # Android Watch
+    WATCH = :watch
+    # Android TV
+    TELEVISION = :television
+    # Android Car Automotive
+    AUTOMOTIVE = :automotive
+
+    # Windows
+    WINDOWS = :windows
   end
 end

--- a/lib/app_info/dsym.rb
+++ b/lib/app_info/dsym.rb
@@ -7,10 +7,6 @@ module AppInfo
   class DSYM < File
     include Helper::Archive
 
-    def file_type
-      Format::DSYM
-    end
-
     def each_file(&block)
       files.each { |file| block.call(file) }
     end

--- a/lib/app_info/dsym.rb
+++ b/lib/app_info/dsym.rb
@@ -7,6 +7,11 @@ module AppInfo
   class DSYM < File
     include Helper::Archive
 
+    # @return [Symbol] {Platform}
+    def platform
+      Platform::APPLE
+    end
+
     def each_file(&block)
       files.each { |file| block.call(file) }
     end

--- a/lib/app_info/dsym.rb
+++ b/lib/app_info/dsym.rb
@@ -16,9 +16,9 @@ module AppInfo
       files.each { |file| block.call(file) }
     end
 
-    # @return [Array<DebugInfo>] dsym_files
+    # @return [Array<DebugInfo>] dsym_files files by alphabetical order
     def files
-      @files ||= Dir.children(contents).each_with_object([]) do |file, obj|
+      @files ||= Dir.children(contents).sort.each_with_object([]) do |file, obj|
         obj << DebugInfo.new(::File.join(contents, file))
       end
     end

--- a/lib/app_info/dsym.rb
+++ b/lib/app_info/dsym.rb
@@ -16,6 +16,7 @@ module AppInfo
       files.each { |file| block.call(file) }
     end
 
+    # @return [Array<DebugInfo>] dsym_files
     def files
       @files ||= Dir.children(contents).each_with_object([]) do |file, obj|
         obj << DebugInfo.new(::File.join(contents, file))
@@ -31,6 +32,7 @@ module AppInfo
       @files = nil
     end
 
+    # @return [String] contents path of dsym
     def contents
       @contents ||= lambda {
         return @file if ::File.directory?(@file)

--- a/lib/app_info/error.rb
+++ b/lib/app_info/error.rb
@@ -9,13 +9,7 @@ module AppInfo
 
   class NotFoundError < Error; end
 
-  class NotFoundWinBinraryError < NotFoundError; end
-
   class ProtobufParseError < Error; end
 
-  class UnknownFileTypeError < Error; end
-
-  # @deprecated Correct to the new {UnknownFileTypeError} class because typo.
-  #   It will remove since 2.7.0.
-  class UnkownFileTypeError < Error; end
+  class UnknownFormatError < Error; end
 end

--- a/lib/app_info/file.rb
+++ b/lib/app_info/file.rb
@@ -13,7 +13,8 @@ module AppInfo
     # @return [Symbol] {Format}
     def format
       @format ||= lambda {
-        if instance_of?(AppInfo::File) || instance_of?(AppInfo::Apple)
+        if instance_of?(AppInfo::File) || instance_of?(AppInfo::Apple) ||
+           instance_of?(AppInfo::Android)
           not_implemented_error!(__method__)
         end
 

--- a/lib/app_info/file.rb
+++ b/lib/app_info/file.rb
@@ -10,6 +10,7 @@ module AppInfo
       @logger = logger
     end
 
+    # @return [Symbol] {Format}
     def format
       @format ||= lambda {
         class_name = self.class

--- a/lib/app_info/file.rb
+++ b/lib/app_info/file.rb
@@ -13,7 +13,9 @@ module AppInfo
     # @return [Symbol] {Format}
     def format
       @format ||= lambda {
-        not_implemented_error!(__method__) if instance_of?(AppInfo::File)
+        if instance_of?(AppInfo::File) || instance_of?(AppInfo::Apple)
+          not_implemented_error!(__method__)
+        end
 
         self.class.name.split('::')[-1].downcase.to_sym
       }.call

--- a/lib/app_info/file.rb
+++ b/lib/app_info/file.rb
@@ -10,9 +10,15 @@ module AppInfo
       @logger = logger
     end
 
-    # @abstract Subclass and override {#file_type} to implement
-    def file_type
-      Platform::UNKNOWN
+    def format
+      @format ||= lambda {
+        class_name = self.class
+        if self.class == AppInfo::File
+          raise NotImplementedError, ".#{__method__} method implantation required in #{self.class}"
+        end
+
+        class_name.name.split('::')[-1].downcase.to_sym
+      }.call
     end
 
     # @abstract Subclass and override {#size} to implement

--- a/lib/app_info/file.rb
+++ b/lib/app_info/file.rb
@@ -13,10 +13,9 @@ module AppInfo
     # @return [Symbol] {Format}
     def format
       @format ||= lambda {
-        class_name = self.class
-        not_implemented_error!(__method__) if self.class.instance_of?(AppInfo::File)
+        not_implemented_error!(__method__) if instance_of?(AppInfo::File)
 
-        class_name.name.split('::')[-1].downcase.to_sym
+        self.class.name.split('::')[-1].downcase.to_sym
       }.call
     end
 

--- a/lib/app_info/file.rb
+++ b/lib/app_info/file.rb
@@ -13,17 +13,34 @@ module AppInfo
     def format
       @format ||= lambda {
         class_name = self.class
-        if self.class == AppInfo::File
-          raise NotImplementedError, ".#{__method__} method implantation required in #{self.class}"
-        end
+        not_implemented_error!(__method__) if self.class.instance_of?(AppInfo::File)
 
         class_name.name.split('::')[-1].downcase.to_sym
       }.call
     end
 
+    # @abstract Subclass and override {#opera_system} to implement.
+    def opera_system
+      not_implemented_error!(__method__)
+    end
+
+    # @abstract Subclass and override {#platform} to implement.
+    def platform
+      not_implemented_error!(__method__)
+    end
+
+    # @abstract Subclass and override {#device} to implement.
+    def device
+      not_implemented_error!(__method__)
+    end
+
     # @abstract Subclass and override {#size} to implement
     def size(human_size: false)
-      raise NotImplementedError, ".#{__method__} method implantation required in #{self.class}"
+      not_implemented_error!(__method__)
+    end
+
+    def not_implemented_error!(method)
+      raise NotImplementedError, ".#{method} method implantation required in #{self.class}"
     end
   end
 end

--- a/lib/app_info/helper/file_size.rb
+++ b/lib/app_info/helper/file_size.rb
@@ -16,7 +16,7 @@ module AppInfo::Helper
         max_exp = FILE_SIZE_UNITS.size - 1
         exponent = (Math.log(number) / Math.log(1024)).to_i
         exponent = max_exp if exponent > max_exp
-        number = format('%<number>.2f', number: (number / (1024**exponent.to_f)))
+        number = Kernel.format('%<number>.2f', number: (number / (1024**exponent.to_f)))
       end
 
       "#{number} #{FILE_SIZE_UNITS[exponent]}"

--- a/lib/app_info/info_plist.rb
+++ b/lib/app_info/info_plist.rb
@@ -17,10 +17,6 @@ module AppInfo
       Device::MACOS => %w[CFBundleIconFile CFBundleIconName]
     }.freeze
 
-    def file_type
-      Format::INFOPLIST
-    end
-
     def version
       release_version || build_version
     end

--- a/lib/app_info/info_plist.rb
+++ b/lib/app_info/info_plist.rb
@@ -47,77 +47,90 @@ module AppInfo
       end
     end
 
+    # @return [String, nil]
     def version
       release_version || build_version
     end
 
+    # @return [String, nil]
     def build_version
       info.try(:[], 'CFBundleVersion')
     end
 
+    # @return [String, nil]
     def release_version
       info.try(:[], 'CFBundleShortVersionString')
     end
 
+    # @return [String, nil]
     def identifier
       info.try(:[], 'CFBundleIdentifier')
     end
     alias bundle_id identifier
 
+    # @return [String, nil]
     def name
       display_name || bundle_name
     end
 
+    # @return [String, nil]
     def display_name
       info.try(:[], 'CFBundleDisplayName')
     end
 
+    # @return [String, nil]
     def bundle_name
       info.try(:[], 'CFBundleName')
     end
 
+    # @return [String, nil]
     def min_os_version
       min_sdk_version || min_system_version
     end
 
-    #
     # Extract the Minimum OS Version from the Info.plist (iOS Only)
-    #
+    # @return [String, nil]
     def min_sdk_version
       info.try(:[], 'MinimumOSVersion')
     end
 
-    #
     # Extract the Minimum OS Version from the Info.plist (macOS Only)
-    #
+    # @return [String, nil]
     def min_system_version
       info.try(:[], 'LSMinimumSystemVersion')
     end
 
+    # @return [Array<String>]
     def icons
       @icons ||= ICON_KEYS[device]
     end
 
+    # @return [Boolean]
     def iphone?
       device == Device::IPHONE
     end
 
+    # @return [Boolean]
     def ipad?
       device == Device::IPAD
     end
 
+    # @return [Boolean]
     def universal?
       device == Device::UNIVERSAL
     end
 
+    # @return [Boolean]
     def macos?
       device == Device::MACOS
     end
 
+    # @return [Array<String>]
     def device_family
       info.try(:[], 'UIDeviceFamily') || []
     end
 
+    # @return [String]
     def release_type
       if stored?
         'Store'
@@ -126,6 +139,7 @@ module AppInfo
       end
     end
 
+    # @return [String, nil]
     def [](key)
       info.try(:[], key.to_s)
     end

--- a/lib/app_info/ipa.rb
+++ b/lib/app_info/ipa.rb
@@ -38,10 +38,6 @@ module AppInfo
       file_to_human_size(@file, human_size: human_size)
     end
 
-    def file_type
-      Format::IPA
-    end
-
     def platform
       Platform::IOS
     end

--- a/lib/app_info/ipa.rb
+++ b/lib/app_info/ipa.rb
@@ -8,9 +8,9 @@ require 'cfpropertylist'
 module AppInfo
   # IPA parser
   class IPA < File
+    extend Forwardable
     include Helper::HumanFileSize
     include Helper::Archive
-    extend Forwardable
 
     attr_reader :file
 
@@ -38,14 +38,53 @@ module AppInfo
       file_to_human_size(@file, human_size: human_size)
     end
 
+    # @return [Symbol] {Platform}
     def platform
-      Platform::IOS
+      Platform::APPLE
     end
 
-    def_delegators :info, :iphone?, :ipad?, :universal?, :build_version, :name,
-                   :release_version, :identifier, :bundle_id, :display_name,
-                   :bundle_name, :min_sdk_version, :min_os_version, :device_type
+    # @!method device
+    #   @see InfoPlist#device
+    # @!method opera_system
+    #   @see InfoPlist#opera_system
+    # @!method iphone?
+    #   @see InfoPlist#iphone?
+    # @!method ipad?
+    #   @see InfoPlist#ipad?
+    # @!method universal?
+    #   @see InfoPlist#universal?
+    # @!method build_version
+    #   @see InfoPlist#build_version
+    # @!method name
+    #   @see InfoPlist#name
+    # @!method release_version
+    #   @see InfoPlist#release_version
+    # @!method identifier
+    #   @see InfoPlist#identifier
+    # @!method bundle_id
+    #   @see InfoPlist#bundle_id
+    # @!method display_name
+    #   @see InfoPlist#display_name
+    # @!method bundle_name
+    #   @see InfoPlist#bundle_name
+    # @!method min_sdk_version
+    #   @see InfoPlist#min_sdk_version
+    # @!method min_os_version
+    #   @see InfoPlist#min_os_version
+    def_delegators :info, :device, :opera_system, :iphone?, :ipad?, :universal?,
+                   :build_version, :name, :release_version, :identifier, :bundle_id,
+                   :display_name, :bundle_name, :min_sdk_version, :min_os_version
 
+    # @!method devices
+    #   @see MobileProvision#devices
+    # @!method team_name
+    #   @see MobileProvision#team_name
+    # @!method team_identifier
+    #   @see MobileProvision#team_identifier
+    # @!method profile_name
+    #   @see MobileProvision#profile_name
+    # @!method expired_date
+    #   @see MobileProvision#expired_date
     def_delegators :mobileprovision, :devices, :team_name, :team_identifier,
                    :profile_name, :expired_date
 
@@ -222,12 +261,12 @@ module AppInfo
     end
 
     def icon_keys
-      @icon_keys ||= case device_type
-                     when 'iPhone'
+      @icon_keys ||= case device
+                     when Device::IPHONE
                        [IPHONE_KEY]
-                     when 'iPad'
+                     when Device::IPAD
                        [IPAD_KEY]
-                     when 'Universal'
+                     when Device::UNIVERSAL
                        [IPHONE_KEY, IPAD_KEY]
                      end
     end

--- a/lib/app_info/ipa.rb
+++ b/lib/app_info/ipa.rb
@@ -6,131 +6,7 @@ require 'forwardable'
 require 'cfpropertylist'
 
 module AppInfo
-  # IPA parser
-  class IPA < File
-    extend Forwardable
-    include Helper::HumanFileSize
-    include Helper::Archive
-
-    attr_reader :file
-
-    # iOS Export types
-    module ExportType
-      DEBUG   = 'Debug'
-      ADHOC   = 'AdHoc'
-      ENTERPRISE = 'Enterprise'
-      RELEASE = 'Release'
-      UNKOWN  = nil
-
-      INHOUSE = 'Enterprise' # Rename and Alias to enterprise
-    end
-
-    # return file size
-    # @example Read file size in integer
-    #   aab.size                    # => 3618865
-    #
-    # @example Read file size in human readabale
-    #   aab.size(human_size: true)  # => '3.45 MB'
-    #
-    # @param [Boolean] human_size Convert integer value to human readable.
-    # @return [Integer, String]
-    def size(human_size: false)
-      file_to_human_size(@file, human_size: human_size)
-    end
-
-    # @return [Symbol] {Platform}
-    def platform
-      Platform::APPLE
-    end
-
-    # @!method device
-    #   @see InfoPlist#device
-    # @!method opera_system
-    #   @see InfoPlist#opera_system
-    # @!method iphone?
-    #   @see InfoPlist#iphone?
-    # @!method ipad?
-    #   @see InfoPlist#ipad?
-    # @!method universal?
-    #   @see InfoPlist#universal?
-    # @!method build_version
-    #   @see InfoPlist#build_version
-    # @!method name
-    #   @see InfoPlist#name
-    # @!method release_version
-    #   @see InfoPlist#release_version
-    # @!method identifier
-    #   @see InfoPlist#identifier
-    # @!method bundle_id
-    #   @see InfoPlist#bundle_id
-    # @!method display_name
-    #   @see InfoPlist#display_name
-    # @!method bundle_name
-    #   @see InfoPlist#bundle_name
-    # @!method min_sdk_version
-    #   @see InfoPlist#min_sdk_version
-    # @!method min_os_version
-    #   @see InfoPlist#min_os_version
-    def_delegators :info, :device, :opera_system, :iphone?, :ipad?, :universal?,
-                   :build_version, :name, :release_version, :identifier, :bundle_id,
-                   :display_name, :bundle_name, :min_sdk_version, :min_os_version
-
-    # @!method devices
-    #   @see MobileProvision#devices
-    # @!method team_name
-    #   @see MobileProvision#team_name
-    # @!method team_identifier
-    #   @see MobileProvision#team_identifier
-    # @!method profile_name
-    #   @see MobileProvision#profile_name
-    # @!method expired_date
-    #   @see MobileProvision#expired_date
-    def_delegators :mobileprovision, :devices, :team_name, :team_identifier,
-                   :profile_name, :expired_date
-
-    # @return [String, nil]
-    def distribution_name
-      "#{profile_name} - #{team_name}" if profile_name && team_name
-    end
-
-    # @return [String]
-    def release_type
-      if stored?
-        ExportType::RELEASE
-      else
-        build_type
-      end
-    end
-
-    # @return [String]
-    def build_type
-      if mobileprovision?
-        if devices
-          ExportType::ADHOC
-        else
-          ExportType::ENTERPRISE
-        end
-      else
-        ExportType::DEBUG
-      end
-    end
-
-    # @return [MachO]
-    def archs
-      return unless ::File.exist?(bundle_path)
-
-      file = MachO.open(bundle_path)
-      case file
-      when MachO::MachOFile
-        [file.cpusubtype]
-      else
-        file.machos.each_with_object([]) do |arch, obj|
-          obj << arch.cpusubtype
-        end
-      end
-    end
-    alias architectures archs
-
+  class IPA < Apple
     # Full icons metadata
     # @example
     #   aab.icons
@@ -170,25 +46,6 @@ module AppInfo
       @frameworks ||= Framework.parse(app_path)
     end
 
-    # force remove developer certificate data from {#mobileprovision} method
-    # @return [nil]
-    def hide_developer_certificates
-      mobileprovision.delete('DeveloperCertificates') if mobileprovision?
-    end
-
-    # @return [MobileProvision]
-    def mobileprovision
-      return unless mobileprovision?
-      return @mobileprovision if @mobileprovision
-
-      @mobileprovision = MobileProvision.new(mobileprovision_path)
-    end
-
-    # @return [Boolean]
-    def mobileprovision?
-      ::File.exist?(mobileprovision_path)
-    end
-
     # @return [String]
     def mobileprovision_path
       filename = 'embedded.mobileprovision'
@@ -218,13 +75,8 @@ module AppInfo
     end
 
     # @return [String]
-    def bundle_path
-      @bundle_path ||= ::File.join(app_path, info.bundle_name)
-    end
-
-    # @return [InfoPlist]
-    def info
-      @info ||= InfoPlist.new(info_path)
+    def binary_path
+      @binary_path ||= ::File.join(app_path, info.bundle_name)
     end
 
     # @return [String]
@@ -236,9 +88,6 @@ module AppInfo
     def app_path
       @app_path ||= Dir.glob(::File.join(contents, 'Payload', '*.app')).first
     end
-
-    IPHONE_KEY = 'CFBundleIcons'
-    IPAD_KEY = 'CFBundleIcons~ipad'
 
     # @return [Array<String>]
     def icons_path
@@ -274,11 +123,6 @@ module AppInfo
       @icons = nil
     end
 
-    # @return [String] contents path of contents
-    def contents
-      @contents ||= unarchive(@file, prefix: 'ios')
-    end
-
     private
 
     def build_icon_metadata(file, uncrush: true)
@@ -298,6 +142,9 @@ module AppInfo
       PngUncrush.decompress(src_file, dest_file)
       ::File.exist?(dest_file) ? dest_file : nil
     end
+
+    IPHONE_KEY = 'CFBundleIcons'
+    IPAD_KEY = 'CFBundleIcons~ipad'
 
     def icon_keys
       @icon_keys ||= case device

--- a/lib/app_info/macos.rb
+++ b/lib/app_info/macos.rb
@@ -62,7 +62,7 @@ module AppInfo
     # @!method min_os_version
     #   @see InfoPlist#min_os_version
     def_delegators :info, :device, :opera_system, :build_version, :name,
-                   :release_version,:identifier, :bundle_id, :display_name,
+                   :release_version, :identifier, :bundle_id, :display_name,
                    :bundle_name, :min_system_version, :min_os_version
 
     # @!method team_name
@@ -76,10 +76,12 @@ module AppInfo
     def_delegators :mobileprovision, :team_name, :team_identifier,
                    :profile_name, :expired_date
 
+    # @return [String, nil]
     def distribution_name
       "#{profile_name} - #{team_name}" if profile_name && team_name
     end
 
+    # @return [String]
     def release_type
       if stored?
         ExportType::APPSTORE
@@ -90,10 +92,37 @@ module AppInfo
       end
     end
 
+    # @return [Boolean]
     def stored?
       ::File.exist?(store_path)
     end
 
+    # Full icons metadata
+    # @param [Boolean] convert Convert .icons to .png format
+    # @example uncovert .icons
+    #   macos.icons
+    #   # => [
+    #   #   {
+    #   #     name: 'icon.icns',
+    #   #     file: '/path/to/icon.icns',
+    #   #   }
+    #   # ]
+    #
+    # @example coverted .icons
+    #   macos.icons(convert: true)
+    #   # => [
+    #   #   {
+    #   #     name: 'converted_icon_32x32.png',
+    #   #     file: '/path/to/converted_icon_32x32.png',
+    #   #     dimensions: [32, 32]
+    #   #   },
+    #   #   {
+    #   #     name: 'converted_icon_120x120.png',
+    #   #     file: '/path/to/converted_icon_120x120.png',
+    #   #     dimensions: [120, 120]
+    #   #   },
+    #   # ]
+    # @return [Array<Hash{Symbol => String, Array<Integer>}>] icons paths of icons
     def icons(convert: true)
       return unless icon_file
 
@@ -106,6 +135,7 @@ module AppInfo
       data
     end
 
+    # @return [MachO]
     def archs
       return unless ::File.exist?(binary_path)
 
@@ -121,28 +151,35 @@ module AppInfo
     end
     alias architectures archs
 
+    # force remove developer certificate data from {#mobileprovision} method
+    # @return [nil]
     def hide_developer_certificates
       mobileprovision.delete('DeveloperCertificates') if mobileprovision?
     end
 
+    # @return [MobileProvision]
     def mobileprovision
       return unless mobileprovision?
 
       @mobileprovision ||= MobileProvision.new(mobileprovision_path)
     end
 
+    # @return [Boolean]
     def mobileprovision?
       ::File.exist?(mobileprovision_path)
     end
 
+    # @return [String]
     def mobileprovision_path
       @mobileprovision_path ||= ::File.join(app_path, 'Contents', 'embedded.provisionprofile')
     end
 
+    # @return [String]
     def store_path
       @store_path ||= ::File.join(app_path, 'Contents', '_MASReceipt', 'receipt')
     end
 
+    # @return [String]
     def binary_path
       return @binary_path if @binary_path
 
@@ -153,14 +190,17 @@ module AppInfo
       @binary_path ||= Dir.glob(::File.join(base_path, '*')).first
     end
 
+    # @return [InfoPlist]
     def info
       @info ||= InfoPlist.new(info_path)
     end
 
+    # @return [String]
     def info_path
       @info_path ||= ::File.join(app_path, 'Contents', 'Info.plist')
     end
 
+    # @return [String]
     def app_path
       @app_path ||= Dir.glob(::File.join(contents, '*.app')).first
     end

--- a/lib/app_info/macos.rb
+++ b/lib/app_info/macos.rb
@@ -34,10 +34,6 @@ module AppInfo
       file_to_human_size(@file, human_size: human_size)
     end
 
-    def file_type
-      Format::MACOS
-    end
-
     def platform
       Platform::MACOS
     end

--- a/lib/app_info/macos.rb
+++ b/lib/app_info/macos.rb
@@ -7,95 +7,10 @@ require 'cfpropertylist'
 
 module AppInfo
   # MacOS App parser
-  class Macos < File
-    include Helper::HumanFileSize
-    include Helper::Archive
-    extend Forwardable
-
-    attr_reader :file
-
-    # macOS Export types
-    module ExportType
-      DEBUG = 'Debug'
-      RELEASE = 'Release'
-      APPSTORE = 'AppStore'
-    end
-
-    # @return [Symbol] {Platform}
-    def platform
-      Platform::APPLE
-    end
-
-    # return file size
-    # @example Read file size in integer
-    #   aab.size                    # => 3618865
-    #
-    # @example Read file size in human readabale
-    #   aab.size(human_size: true)  # => '3.45 MB'
-    #
-    # @param [Boolean] human_size Convert integer value to human readable.
-    # @return [Integer, String]
-    def size(human_size: false)
-      file_to_human_size(@file, human_size: human_size)
-    end
-
-    # @!method device
-    #   @see InfoPlist#device
-    # @!method opera_system
-    #   @see InfoPlist#opera_system
-    # @!method build_version
-    #   @see InfoPlist#build_version
-    # @!method name
-    #   @see InfoPlist#name
-    # @!method release_version
-    #   @see InfoPlist#release_version
-    # @!method identifier
-    #   @see InfoPlist#identifier
-    # @!method bundle_id
-    #   @see InfoPlist#bundle_id
-    # @!method display_name
-    #   @see InfoPlist#display_name
-    # @!method bundle_name
-    #   @see InfoPlist#bundle_name
+  class Macos < Apple
     # @!method min_sdk_version
     #   @see InfoPlist#min_sdk_version
-    # @!method min_os_version
-    #   @see InfoPlist#min_os_version
-    def_delegators :info, :device, :opera_system, :build_version, :name,
-                   :release_version, :identifier, :bundle_id, :display_name,
-                   :bundle_name, :min_system_version, :min_os_version
-
-    # @!method team_name
-    #   @see MobileProvision#team_name
-    # @!method team_identifier
-    #   @see MobileProvision#team_identifier
-    # @!method profile_name
-    #   @see MobileProvision#profile_name
-    # @!method expired_date
-    #   @see MobileProvision#expired_date
-    def_delegators :mobileprovision, :team_name, :team_identifier,
-                   :profile_name, :expired_date
-
-    # @return [String, nil]
-    def distribution_name
-      "#{profile_name} - #{team_name}" if profile_name && team_name
-    end
-
-    # @return [String]
-    def release_type
-      if stored?
-        ExportType::APPSTORE
-      elsif mobileprovision?
-        ExportType::RELEASE
-      else
-        ExportType::DEBUG
-      end
-    end
-
-    # @return [Boolean]
-    def stored?
-      ::File.exist?(store_path)
-    end
+    def_delegators :info, :min_system_version
 
     # Full icons metadata
     # @param [Boolean] convert Convert .icons to .png format
@@ -135,38 +50,9 @@ module AppInfo
       data
     end
 
-    # @return [MachO]
-    def archs
-      return unless ::File.exist?(binary_path)
-
-      file = MachO.open(binary_path)
-      case file
-      when MachO::MachOFile
-        [file.cpusubtype]
-      else
-        file.machos.each_with_object([]) do |arch, obj|
-          obj << arch.cpusubtype
-        end
-      end
-    end
-    alias architectures archs
-
-    # force remove developer certificate data from {#mobileprovision} method
-    # @return [nil]
-    def hide_developer_certificates
-      mobileprovision.delete('DeveloperCertificates') if mobileprovision?
-    end
-
-    # @return [MobileProvision]
-    def mobileprovision
-      return unless mobileprovision?
-
-      @mobileprovision ||= MobileProvision.new(mobileprovision_path)
-    end
-
     # @return [Boolean]
-    def mobileprovision?
-      ::File.exist?(mobileprovision_path)
+    def stored?
+      ::File.exist?(store_path)
     end
 
     # @return [String]
@@ -190,11 +76,6 @@ module AppInfo
       @binary_path ||= Dir.glob(::File.join(base_path, '*')).first
     end
 
-    # @return [InfoPlist]
-    def info
-      @info ||= InfoPlist.new(info_path)
-    end
-
     # @return [String]
     def info_path
       @info_path ||= ::File.join(app_path, 'Contents', 'Info.plist')
@@ -216,10 +97,6 @@ module AppInfo
       @info_path = nil
       @info = nil
       @icons = nil
-    end
-
-    def contents
-      @contents ||= unarchive(@file, prefix: 'macos')
     end
 
     private

--- a/lib/app_info/macos.rb
+++ b/lib/app_info/macos.rb
@@ -21,6 +21,11 @@ module AppInfo
       APPSTORE = 'AppStore'
     end
 
+    # @return [Symbol] {Platform}
+    def platform
+      Platform::APPLE
+    end
+
     # return file size
     # @example Read file size in integer
     #   aab.size                    # => 3618865
@@ -34,14 +39,40 @@ module AppInfo
       file_to_human_size(@file, human_size: human_size)
     end
 
-    def platform
-      Platform::MACOS
-    end
+    # @!method device
+    #   @see InfoPlist#device
+    # @!method opera_system
+    #   @see InfoPlist#opera_system
+    # @!method build_version
+    #   @see InfoPlist#build_version
+    # @!method name
+    #   @see InfoPlist#name
+    # @!method release_version
+    #   @see InfoPlist#release_version
+    # @!method identifier
+    #   @see InfoPlist#identifier
+    # @!method bundle_id
+    #   @see InfoPlist#bundle_id
+    # @!method display_name
+    #   @see InfoPlist#display_name
+    # @!method bundle_name
+    #   @see InfoPlist#bundle_name
+    # @!method min_sdk_version
+    #   @see InfoPlist#min_sdk_version
+    # @!method min_os_version
+    #   @see InfoPlist#min_os_version
+    def_delegators :info, :device, :opera_system, :build_version, :name,
+                   :release_version,:identifier, :bundle_id, :display_name,
+                   :bundle_name, :min_system_version, :min_os_version
 
-    def_delegators :info, :macos?, :iphone?, :ipad?, :universal?, :build_version, :name,
-                   :release_version, :identifier, :bundle_id, :display_name,
-                   :bundle_name, :min_system_version, :min_os_version, :device_type
-
+    # @!method team_name
+    #   @see MobileProvision#team_name
+    # @!method team_identifier
+    #   @see MobileProvision#team_identifier
+    # @!method profile_name
+    #   @see MobileProvision#profile_name
+    # @!method expired_date
+    #   @see MobileProvision#expired_date
     def_delegators :mobileprovision, :team_name, :team_identifier,
                    :profile_name, :expired_date
 

--- a/lib/app_info/mobile_provision.rb
+++ b/lib/app_info/mobile_provision.rb
@@ -24,14 +24,17 @@ module AppInfo
       end
     end
 
+    # @return [String, nil]
     def name
       mobileprovision.try(:[], 'Name')
     end
 
+    # @return [String, nil]
     def app_name
       mobileprovision.try(:[], 'AppIDName')
     end
 
+    # @return [Symbol, nil]
     def type
       return :development if development?
       return :adhoc if adhoc?
@@ -49,30 +52,37 @@ module AppInfo
       end
     end
 
+    # @return [Array<String>, nil]
     def devices
       mobileprovision.try(:[], 'ProvisionedDevices')
     end
 
+    # @return [String, nil]
     def team_identifier
       mobileprovision.try(:[], 'TeamIdentifier')
     end
 
+    # @return [String, nil]
     def team_name
       mobileprovision.try(:[], 'TeamName')
     end
 
+    # @return [String, nil]
     def profile_name
       mobileprovision.try(:[], 'Name')
     end
 
+    # @return [String, nil]
     def created_date
       mobileprovision.try(:[], 'CreationDate')
     end
 
+    # @return [String, nil]
     def expired_date
       mobileprovision.try(:[], 'ExpirationDate')
     end
 
+    # @return [Array<String>, nil]
     def entitlements
       mobileprovision.try(:[], 'Entitlements')
     end
@@ -98,7 +108,8 @@ module AppInfo
 
     # Detect is development type of mobileprovision
     #
-    # related link: https://stackoverflow.com/questions/1003066/what-does-get-task-allow-do-in-xcode
+    # @see https://stackoverflow.com/questions/1003066/what-does-get-task-allow-do-in-xcode
+    # @return [Boolea]
     def development?
       case opera_system
       when OperaSystem::IOS
@@ -112,7 +123,8 @@ module AppInfo
 
     # Detect app store type
     #
-    # related link: https://developer.apple.com/library/archive/qa/qa1830/_index.html
+    # @see https://developer.apple.com/library/archive/qa/qa1830/_index.html
+    # @return [Boolea]
     def appstore?
       case opera_system
       when OperaSystem::IOS
@@ -124,12 +136,14 @@ module AppInfo
       end
     end
 
+    # @return [Boolea]
     def adhoc?
       return false if opera_system == OperaSystem::MACOS # macOS no need adhoc
 
       !development? && !devices.nil?
     end
 
+    # @return [Boolea]
     def enterprise?
       return false if opera_system == OperaSystem::MACOS # macOS no need adhoc
 
@@ -139,7 +153,8 @@ module AppInfo
 
     # Enabled Capabilites
     #
-    # Related link: https://developer.apple.com/support/app-capabilities/
+    # @see https://developer.apple.com/support/app-capabilities/
+    # @return [Array<String>]
     def enabled_capabilities
       capabilities = []
       capabilities << 'In-App Purchase' << 'GameKit' if adhoc? || appstore?
@@ -213,14 +228,17 @@ module AppInfo
       capabilities
     end
 
+    # @return [String, nil]
     def [](key)
       mobileprovision.try(:[], key.to_s)
     end
 
+    # @return [Boolea]
     def empty?
       mobileprovision.nil?
     end
 
+    # @return [CFPropertyList]
     def mobileprovision
       return @mobileprovision = nil unless ::File.exist?(@file)
 

--- a/lib/app_info/mobile_provision.rb
+++ b/lib/app_info/mobile_provision.rb
@@ -6,10 +6,6 @@ require 'cfpropertylist'
 module AppInfo
   # .mobileprovision file parser
   class MobileProvision < File
-    def file_type
-      Format::MOBILEPROVISION
-    end
-
     def name
       mobileprovision.try(:[], 'Name')
     end

--- a/lib/app_info/mobile_provision.rb
+++ b/lib/app_info/mobile_provision.rb
@@ -117,7 +117,7 @@ module AppInfo
       when OperaSystem::MACOS
         !devices.nil?
       else
-        raise Error, "Not implement with opera_system: #{opera_system}"
+        raise NotImplementedError, "Unknown opera_system: #{opera_system}"
       end
     end
 
@@ -132,7 +132,7 @@ module AppInfo
       when OperaSystem::MACOS
         !development?
       else
-        raise Error, "Not implement with opera_system: #{opera_system}"
+        raise NotImplementedError, "Unknown opera_system: #{opera_system}"
       end
     end
 

--- a/lib/app_info/pe.rb
+++ b/lib/app_info/pe.rb
@@ -24,10 +24,6 @@ module AppInfo
       0x5128 => 'RISC-v 128'
     }.freeze
 
-    def file_type
-      Format::PE
-    end
-
     def platform
       Platform::WINDOWS
     end

--- a/lib/app_info/pe.rb
+++ b/lib/app_info/pe.rb
@@ -56,23 +56,38 @@ module AppInfo
       file_to_human_size(binary_file, human_size: human_size)
     end
 
+    # @!method product_name
+    #   @see VersionInfo#product_name
+    #   @return [String]
+    # @!method product_version
+    #   @see VersionInfo#product_version
+    #   @return [String]
+    # @!method company_name
+    #   @see VersionInfo#company_name
+    #   @return [String]
+    # @!method assembly_version
+    #   @see VersionInfo#assembly_version
+    #   @return [String]
     def_delegators :version_info, :product_name, :product_version, :company_name, :assembly_version
 
     alias name product_name
     alias release_version product_version
     alias build_version assembly_version
 
+    # @return [String]
     def archs
       ARCH[image_file_header.Machine] || 'unknown'
     end
     alias architectures archs
 
+    # @return [Hash{String => String}] imports imports of libraries
     def imports
       @imports ||= pe.imports.each_with_object({}) do |import, obj|
         obj[import.module_name] = import.first_thunk.map(&:name).compact
       end
     end
 
+    # @return [Array{String}] icons paths of bmp image icons
     def icons
       @icons ||= lambda {
         # Fetch the largest size icon
@@ -112,6 +127,7 @@ module AppInfo
       }.call
     end
 
+    # @return [PEdump]
     def pe
       @pe ||= lambda {
         pe = PEdump.new(io)
@@ -120,6 +136,7 @@ module AppInfo
       }.call
     end
 
+    # @return [VersionInfo]
     def version_info
       @version_info ||= VersionInfo.new(pe.version_info)
     end
@@ -131,6 +148,7 @@ module AppInfo
       @imports = nil
     end
 
+    # @return [String] binary_file path
     def binary_file
       @binary_file ||= lambda {
         file_io = ::File.open(@file, 'rb')
@@ -154,6 +172,7 @@ module AppInfo
       @image_file_header ||= pe.pe.image_file_header
     end
 
+    # @return [Hash{Symbol => String}]
     def icon_metadata(file, mask_file: nil)
       {
         name: ::File.basename(file),
@@ -163,6 +182,7 @@ module AppInfo
       }
     end
 
+    # @return [File]
     def io
       @io ||= ::File.open(binary_file, 'rb')
     end
@@ -175,30 +195,37 @@ module AppInfo
         @raw = raw
       end
 
+      # @return [String]
       def company_name
         @company_name ||= value_of('CompanyName')
       end
 
+      # @return [String]
       def product_name
         @product_name ||= value_of('ProductName')
       end
 
+      # @return [String]
       def product_version
         @product_version ||= value_of('ProductVersion')
       end
 
+      # @return [String]
       def assembly_version
         @assembly_version ||= value_of('Assembly Version')
       end
 
+      # @return [String]
       def file_version
         @file_version ||= value_of('FileVersion')
       end
 
+      # @return [String]
       def file_description
         @file_description ||= value_of('FileDescription')
       end
 
+      # @return [String]
       def copyright
         @copyright ||= value_of('LegalCopyright')
       end

--- a/lib/app_info/pe.rb
+++ b/lib/app_info/pe.rb
@@ -24,8 +24,19 @@ module AppInfo
       0x5128 => 'RISC-v 128'
     }.freeze
 
+    # @return [Symbol] {Platform}
     def platform
       Platform::WINDOWS
+    end
+
+    # @return [Symbol] {OperaSystem}
+    def opera_system
+      OperaSystem::WINDOWS
+    end
+
+    # @return [Symbol] {Device}
+    def device
+      Device::WINDOWS
     end
 
     # return file size

--- a/lib/app_info/pe.rb
+++ b/lib/app_info/pe.rb
@@ -156,7 +156,7 @@ module AppInfo
 
         zip_file = Zip::File.open(@file)
         zip_entry = zip_file.glob('*.exe').first
-        raise NotFoundWinBinraryError, 'Not found .exe file in archive file' if zip_entry.nil?
+        raise NotFoundError, 'Not found .exe file in archive file' if zip_entry.nil?
 
         exe_file = tempdir(zip_entry.name, prefix: 'pe-exe', system: true)
         zip_entry.extract(exe_file)

--- a/lib/app_info/png_uncrush.rb
+++ b/lib/app_info/png_uncrush.rb
@@ -32,18 +32,24 @@ module AppInfo
         @data = String.new
       end
 
+      # @return [Integer]
       def size
         @io.size
       end
 
+      # @param [String] format
+      # @return [String]
+      # @see IO package data
       def unpack(format)
         @io.unpack(format)
       end
 
+      # @return [String]
       def header
         @header ||= self[0, 8]
       end
 
+      # @return [Boolean]
       def png?
         header.bytes == PNG_HEADER
       end
@@ -61,10 +67,17 @@ module AppInfo
       end
     end
 
+    # Decompress crushed png file.
+    # @param [String] input path of png file
+    # @param [String] output path of output file
+    # @return [Boolean] result whether decompress successfully
     def self.decompress(input, output)
       new(input).decompress(output)
     end
 
+    # get png dimensions
+    # @param [String] input path of png file
+    # @return [Array<Integer>] dimensions width, height value of png file
     def self.dimensions(input)
       new(input).dimensions
     end
@@ -74,10 +87,16 @@ module AppInfo
       raise FormatError, 'not a png file' unless @io.png?
     end
 
+    # get png dimensions
+    # @param [String] input path of png file
+    # @return [Array<Integer>] dimensions width, height value of png file
     def dimensions
       _dump_sections(dimensions: true)
     end
 
+    # Decompress crushed png file.
+    # @param [String] output path of output file
+    # @return [Boolean] result whether decompress successfully
     def decompress(output)
       content = _remap(_dump_sections)
       return false unless content

--- a/lib/app_info/proguard.rb
+++ b/lib/app_info/proguard.rb
@@ -10,8 +10,8 @@ module AppInfo
 
     NAMESPACE = UUIDTools::UUID.sha1_create(UUIDTools::UUID_DNS_NAMESPACE, 'icyleaf.com')
 
-    def file_type
-      Format::PROGUARD
+    def platform
+      Platform::ANDROID
     end
 
     def uuid

--- a/lib/app_info/proguard.rb
+++ b/lib/app_info/proguard.rb
@@ -10,8 +10,14 @@ module AppInfo
 
     NAMESPACE = UUIDTools::UUID.sha1_create(UUIDTools::UUID_DNS_NAMESPACE, 'icyleaf.com')
 
+    # @return [Symbol] {Platform}
     def platform
-      Platform::ANDROID
+      Platform::GOOGLE
+    end
+
+    # @return [Symbol] {OperaSystem}
+    def opera_system
+      OperaSystem::ANDROID
     end
 
     def uuid

--- a/lib/app_info/proguard.rb
+++ b/lib/app_info/proguard.rb
@@ -20,37 +20,44 @@ module AppInfo
       OperaSystem::ANDROID
     end
 
+    # @return [String]
     def uuid
       # Similar to https://docs.sentry.io/workflow/debug-files/#proguard-uuids
       UUIDTools::UUID.sha1_create(NAMESPACE, ::File.read(mapping_path)).to_s
     end
     alias debug_id uuid
 
+    # @return [Boolean]
     def mapping?
       ::File.exist?(mapping_path)
     end
 
+    # @return [Boolean]
     def manifest?
       ::File.exist?(manifest_path)
     end
 
+    # @return [Boolean]
     def symbol?
       ::File.exist?(symbol_path)
     end
     alias resource? symbol?
 
+    # @return [String, nil]
     def package_name
       return unless manifest?
 
       manifest.root.attributes['package']
     end
 
+    # @return [String, nil]
     def releasd_version
       return unless manifest?
 
       manifest.root.attributes['package']
     end
 
+    # @return [String, nil]
     def version_name
       return unless manifest?
 
@@ -58,6 +65,7 @@ module AppInfo
     end
     alias release_version version_name
 
+    # @return [String, nil]
     def version_code
       return unless manifest?
 
@@ -65,25 +73,30 @@ module AppInfo
     end
     alias build_version version_code
 
+    # @return [REXML::Document]
     def manifest
       return unless manifest?
 
       @manifest ||= REXML::Document.new(::File.new(manifest_path))
     end
 
+    # @return [String]
     def mapping_path
       @mapping_path ||= Dir.glob(::File.join(contents, '*mapping*.txt')).first
     end
 
+    # @return [String]
     def manifest_path
       @manifest_path ||= ::File.join(contents, 'AndroidManifest.xml')
     end
 
+    # @return [String]
     def symbol_path
       @symbol_path ||= ::File.join(contents, 'R.txt')
     end
     alias resource_path symbol_path
 
+    # @return [String] contents path of contents
     def contents
       @contents ||= unarchive(@file, prefix: 'proguard')
     end

--- a/lib/app_info/protobuf/manifest.rb
+++ b/lib/app_info/protobuf/manifest.rb
@@ -6,6 +6,7 @@ require 'app_info/core_ext'
 
 module AppInfo
   module Protobuf
+    # AAB Protobuf Base class
     class Base
       include Helper::GenerateClass
 
@@ -21,6 +22,7 @@ module AppInfo
       end
     end
 
+    # AAB Protobuf Attribute
     class Attribute < Base
       attr_reader :namespace, :name, :value, :resource_id
 
@@ -47,6 +49,8 @@ module AppInfo
       end
     end
 
+    # AAB Protobuf Node class.
+    #   example: manifest,activity, activity-alias, service, receiver, provider, application
     class Node < Base
       attr_reader :name, :attributes, :children
 
@@ -106,6 +110,7 @@ module AppInfo
       end
     end
 
+    # AAB Protobuf Manifest
     class Manifest < Node
       def self.parse(io, resources = nil)
         doc = Aapt::Pb::XmlNode.decode(io)
@@ -170,7 +175,6 @@ module AppInfo
         end.flatten.uniq
       end
 
-      # :nodoc:
       # Workaround ruby always return true by called `Object.const_defined?(Data)`
       class Data < Node; end
 

--- a/spec/app_info/aab_spec.rb
+++ b/spec/app_info/aab_spec.rb
@@ -6,16 +6,21 @@ describe AppInfo::APK do
     context 'with Android target SDK under 31' do
       let(:file) { fixture_path('apps/android.aab') }
 
+      it { expect(subject.file).to eq file }
       it { expect(subject.size).to eq(3618865) }
       it { expect(subject.size(human_size: true)).to eq('3.45 MB') }
-      it { expect(subject.file_type).to eq :aab }
-      it { expect(subject.file_type).to eq AppInfo::Format::AAB }
-      it { expect(subject.platform).to eq 'Android' }
-      it { expect(subject.platform).to eq AppInfo::Platform::ANDROID }
-      it { expect(subject.wear?).to be false }
-      it { expect(subject.tv?).to be false }
-      it { expect(subject.automotive?).to be false }
-      it { expect(subject.file).to eq file }
+      it { expect(subject.format).to eq(AppInfo::Format::AAB) }
+      it { expect(subject.format).to eq(:aab) }
+      it { expect(subject.platform).to eq(AppInfo::Platform::GOOGLE) }
+      it { expect(subject.platform).to eq(:google) }
+      it { expect(subject.opera_system).to eq(AppInfo::OperaSystem::ANDROID) }
+      it { expect(subject.opera_system).to eq(:android) }
+      it { expect(subject.device).to eq(AppInfo::Device::PHONE) }
+      it { expect(subject.device).to eq(:phone) }
+      it { expect(subject).not_to be_tablet }
+      it { expect(subject).not_to be_watch }
+      it { expect(subject).not_to be_television }
+      it { expect(subject).not_to be_automotive }
       it { expect(subject.release_version).to eq('2.1.0') }
       it { expect(subject.build_version).to eq('10') }
       it { expect(subject.name).to eq('AppInfoDemo') }
@@ -45,16 +50,21 @@ describe AppInfo::APK do
     context 'with Android target SDK above 31' do
       let(:file) { fixture_path('apps/android-31.aab') }
 
+      it { expect(subject.file).to eq file }
       it { expect(subject.size).to eq(7448532) }
       it { expect(subject.size(human_size: true)).to eq('7.10 MB') }
-      it { expect(subject.file_type).to eq :aab }
-      it { expect(subject.file_type).to eq AppInfo::Format::AAB }
-      it { expect(subject.platform).to eq 'Android' }
-      it { expect(subject.platform).to eq AppInfo::Platform::ANDROID }
-      it { expect(subject.wear?).to be false }
-      it { expect(subject.tv?).to be false }
-      it { expect(subject.automotive?).to be false }
-      it { expect(subject.file).to eq file }
+      it { expect(subject.format).to eq(AppInfo::Format::AAB) }
+      it { expect(subject.format).to eq(:aab) }
+      it { expect(subject.platform).to eq(AppInfo::Platform::GOOGLE) }
+      it { expect(subject.platform).to eq(:google) }
+      it { expect(subject.opera_system).to eq(AppInfo::OperaSystem::ANDROID) }
+      it { expect(subject.opera_system).to eq(:android) }
+      it { expect(subject.device).to eq(AppInfo::Device::PHONE) }
+      it { expect(subject.device).to eq(:phone) }
+      it { expect(subject).not_to be_tablet }
+      it { expect(subject).not_to be_watch }
+      it { expect(subject).not_to be_television }
+      it { expect(subject).not_to be_automotive }
       it { expect(subject.release_version).to eq('1.0') }
       it { expect(subject.build_version).to eq('1') }
       it { expect(subject.name).to eq('My Application') }

--- a/spec/app_info/android_spec.rb
+++ b/spec/app_info/android_spec.rb
@@ -1,0 +1,51 @@
+describe AppInfo::Android do
+  context 'when aab' do
+    let(:file) { fixture_path('apps/android.aab') }
+    subject { AppInfo::Android.new(file) }
+
+    it { expect(subject.file).to eq file }
+    it { expect(subject.size).to eq(3618865) }
+    it { expect(subject.size(human_size: true)).to eq('3.45 MB') }
+    it { expect(subject.platform).to eq(AppInfo::Platform::GOOGLE) }
+    it { expect(subject.platform).to eq(:google) }
+    it { expect(subject.opera_system).to eq(AppInfo::OperaSystem::ANDROID) }
+    it { expect(subject.opera_system).to eq(:android) }
+    it { expect { subject.format }.to raise_error NotImplementedError }
+    it { expect { subject.name }.to raise_error NotImplementedError }
+    it { expect { subject.use_features }.to raise_error NotImplementedError }
+    it { expect { subject.use_permissions }.to raise_error NotImplementedError }
+    it { expect { subject.device }.to raise_error NotImplementedError }
+    it { expect { subject.activities }.to raise_error NotImplementedError }
+    it { expect { subject.services }.to raise_error NotImplementedError }
+    it { expect { subject.components }.to raise_error NotImplementedError }
+    it { expect { subject.manifest }.to raise_error NotImplementedError }
+    it { expect { subject.resource }.to raise_error NotImplementedError }
+    it { expect { subject.zip }.to raise_error NotImplementedError }
+    it { expect { subject.clear! }.to raise_error NotImplementedError }
+  end
+
+  context 'when apk' do
+    let(:file) { fixture_path('apps/android.apk') }
+    subject { AppInfo::Android.new(file) }
+
+    it { expect(subject.file).to eq file }
+    it { expect(subject.size).to eq(4000563) }
+    it { expect(subject.size(human_size: true)).to eq('3.82 MB') }
+    it { expect(subject.platform).to eq(AppInfo::Platform::GOOGLE) }
+    it { expect(subject.platform).to eq(:google) }
+    it { expect(subject.opera_system).to eq(AppInfo::OperaSystem::ANDROID) }
+    it { expect(subject.opera_system).to eq(:android) }
+    it { expect { subject.format }.to raise_error NotImplementedError }
+    it { expect { subject.name }.to raise_error NotImplementedError }
+    it { expect { subject.use_features }.to raise_error NotImplementedError }
+    it { expect { subject.use_permissions }.to raise_error NotImplementedError }
+    it { expect { subject.device }.to raise_error NotImplementedError }
+    it { expect { subject.activities }.to raise_error NotImplementedError }
+    it { expect { subject.services }.to raise_error NotImplementedError }
+    it { expect { subject.components }.to raise_error NotImplementedError }
+    it { expect { subject.manifest }.to raise_error NotImplementedError }
+    it { expect { subject.resource }.to raise_error NotImplementedError }
+    it { expect { subject.zip }.to raise_error NotImplementedError }
+    it { expect { subject.clear! }.to raise_error NotImplementedError }
+  end
+end

--- a/spec/app_info/apk_spec.rb
+++ b/spec/app_info/apk_spec.rb
@@ -6,17 +6,30 @@ describe AppInfo::APK do
 
     context 'with Android min SDK under 24' do
       let(:file) { fixture_path('apps/android.apk') }
+
+      it { expect(subject.file).to eq file }
       it { expect(subject.size).to eq(4000563) }
       it { expect(subject.size(human_size: true)).to eq('3.82 MB') }
-      it { expect(subject.file_type).to eq :apk }
-      it { expect(subject.file_type).to eq AppInfo::Format::APK }
-      it { expect(subject.platform).to eq 'Android' }
-      it { expect(subject.platform).to eq AppInfo::Platform::ANDROID }
-      it { expect(subject.wear?).to be false }
-      it { expect(subject.tv?).to be false }
-      it { expect(subject.automotive?).to be false }
-      it { expect(subject.device_type).to eq AppInfo::APK::Device::PHONE }
-      it { expect(subject.file).to eq file }
+      # it { expect(subject.file_type).to eq :apk }
+      # it { expect(subject.file_type).to eq AppInfo::Format::APK }
+      # it { expect(subject.platform).to eq 'Android' }
+      # it { expect(subject.platform).to eq AppInfo::Platform::ANDROID }
+      # it { expect(subject.wear?).to be false }
+      # it { expect(subject.tv?).to be false }
+      # it { expect(subject.automotive?).to be false }
+      # it { expect(subject.device_type).to eq AppInfo::APK::Device::PHONE }
+      it { expect(subject.format).to eq(AppInfo::Format::APK) }
+      it { expect(subject.format).to eq(:apk) }
+      it { expect(subject.platform).to eq(AppInfo::Platform::GOOGLE) }
+      it { expect(subject.platform).to eq(:google) }
+      it { expect(subject.opera_system).to eq(AppInfo::OperaSystem::ANDROID) }
+      it { expect(subject.opera_system).to eq(:android) }
+      it { expect(subject.device).to eq(AppInfo::Device::PHONE) }
+      it { expect(subject.device).to eq(:phone) }
+      it { expect(subject).not_to be_tablet }
+      it { expect(subject).not_to be_watch }
+      it { expect(subject).not_to be_television }
+      it { expect(subject).not_to be_automotive }
       it { expect(subject.apk).to be_a Android::Apk }
       it { expect(subject.release_version).to eq('2.1.0') }
       it { expect(subject.build_version).to eq('10') }
@@ -51,16 +64,20 @@ describe AppInfo::APK do
 
     after { subject.clear! }
 
-    it { expect(subject.file_type).to eq :apk }
-    it { expect(subject.file_type).to eq AppInfo::Format::APK }
-    it { expect(subject.platform).to eq 'Android' }
-    it { expect(subject.platform).to eq AppInfo::Platform::ANDROID }
-    it { expect(subject.wear?).to be true }
-    it { expect(subject.tv?).to be false }
-    it { expect(subject.automotive?).to be false }
-    it { expect(subject.device_type).to eq AppInfo::APK::Device::WATCH }
     it { expect(subject.file).to eq file }
     it { expect(subject.apk).to be_a Android::Apk }
+    it { expect(subject.format).to eq(AppInfo::Format::APK) }
+    it { expect(subject.format).to eq(:apk) }
+    it { expect(subject.platform).to eq(AppInfo::Platform::GOOGLE) }
+    it { expect(subject.platform).to eq(:google) }
+    it { expect(subject.opera_system).to eq(AppInfo::OperaSystem::ANDROID) }
+    it { expect(subject.opera_system).to eq(:android) }
+    it { expect(subject.device).to eq(AppInfo::Device::WATCH) }
+    it { expect(subject.device).to eq(:watch) }
+    it { expect(subject).not_to be_tablet }
+    it { expect(subject).to be_watch }
+    it { expect(subject).not_to be_television }
+    it { expect(subject).not_to be_automotive }
     it { expect(subject.release_version).to eq('1.0') }
     it { expect(subject.build_version).to eq('1') }
     it { expect(subject.name).to eq('AppInfoWearDemo') }
@@ -77,16 +94,20 @@ describe AppInfo::APK do
 
     after { subject.clear! }
 
-    it { expect(subject.file_type).to eq :apk }
-    it { expect(subject.file_type).to eq AppInfo::Format::APK }
-    it { expect(subject.platform).to eq 'Android' }
-    it { expect(subject.platform).to eq AppInfo::Platform::ANDROID }
-    it { expect(subject.wear?).to be false }
-    it { expect(subject.tv?).to be true }
-    it { expect(subject.automotive?).to be false }
-    it { expect(subject.device_type).to eq AppInfo::APK::Device::TV }
     it { expect(subject.file).to eq file }
     it { expect(subject.apk).to be_a Android::Apk }
+    it { expect(subject.format).to eq(AppInfo::Format::APK) }
+    it { expect(subject.format).to eq(:apk) }
+    it { expect(subject.platform).to eq(AppInfo::Platform::GOOGLE) }
+    it { expect(subject.platform).to eq(:google) }
+    it { expect(subject.opera_system).to eq(AppInfo::OperaSystem::ANDROID) }
+    it { expect(subject.opera_system).to eq(:android) }
+    it { expect(subject.device).to eq(AppInfo::Device::TELEVISION) }
+    it { expect(subject.device).to eq(:television) }
+    it { expect(subject).not_to be_tablet }
+    it { expect(subject).not_to be_watch }
+    it { expect(subject).to be_television }
+    it { expect(subject).not_to be_automotive }
     it { expect(subject.build_version).to eq('1') }
     it { expect(subject.release_version).to eq('1.0') }
     it { expect(subject.name).to eq('AppInfoTVDemo') }
@@ -103,16 +124,20 @@ describe AppInfo::APK do
 
     after { subject.clear! }
 
-    it { expect(subject.file_type).to eq :apk }
-    it { expect(subject.file_type).to eq AppInfo::Format::APK }
-    it { expect(subject.platform).to eq 'Android' }
-    it { expect(subject.platform).to eq AppInfo::Platform::ANDROID }
-    it { expect(subject.wear?).to be false }
-    it { expect(subject.tv?).to be false }
-    it { expect(subject.automotive?).to be true }
-    it { expect(subject.device_type).to eq AppInfo::APK::Device::AUTOMOTIVE }
     it { expect(subject.file).to eq file }
     it { expect(subject.apk).to be_a Android::Apk }
+    it { expect(subject.format).to eq(AppInfo::Format::APK) }
+    it { expect(subject.format).to eq(:apk) }
+    it { expect(subject.platform).to eq(AppInfo::Platform::GOOGLE) }
+    it { expect(subject.platform).to eq(:google) }
+    it { expect(subject.opera_system).to eq(AppInfo::OperaSystem::ANDROID) }
+    it { expect(subject.opera_system).to eq(:android) }
+    it { expect(subject.device).to eq(AppInfo::Device::AUTOMOTIVE) }
+    it { expect(subject.device).to eq(:automotive) }
+    it { expect(subject).not_to be_tablet }
+    it { expect(subject).not_to be_watch }
+    it { expect(subject).not_to be_television }
+    it { expect(subject).to be_automotive }
     it { expect(subject.build_version).to eq('3') }
     it { expect(subject.release_version).to eq('2.0') }
     it { expect(subject.name).to eq('AutoMotive') }

--- a/spec/app_info/apple_spec.rb
+++ b/spec/app_info/apple_spec.rb
@@ -1,0 +1,41 @@
+describe AppInfo::Apple do
+  describe 'when iOS' do
+    let(:file) { fixture_path('apps/iphone.ipa') }
+    subject { AppInfo::Apple.new(file) }
+
+    it { expect(subject.file).to eq file }
+    it { expect(subject.platform).to eq(AppInfo::Platform::APPLE) }
+    it { expect(subject.platform).to eq(:apple) }
+    it { expect { subject.format }.to raise_error NotImplementedError }
+    it { expect { subject.opera_system }.to raise_error NotImplementedError }
+    it { expect { subject.distribution_name }.to raise_error NotImplementedError }
+    it { expect { subject.info }.to raise_error NotImplementedError }
+    it { expect { subject.icons }.to raise_error NotImplementedError }
+    it { expect { subject.stored? }.to raise_error NotImplementedError }
+    it { expect { subject.mobileprovision_path }.to raise_error NotImplementedError }
+    it { expect { subject.info_path }.to raise_error NotImplementedError }
+    it { expect { subject.app_path }.to raise_error NotImplementedError }
+    it { expect { subject.mobileprovision_path }.to raise_error NotImplementedError }
+    it { expect { subject.clear! }.to raise_error NotImplementedError }
+  end
+
+  describe 'when macOS' do
+    let(:file) { fixture_path('apps/macos.zip') }
+    subject { AppInfo::Apple.new(file) }
+
+    it { expect(subject.file).to eq file }
+    it { expect(subject.platform).to eq(AppInfo::Platform::APPLE) }
+    it { expect(subject.platform).to eq(:apple) }
+    it { expect { subject.format }.to raise_error NotImplementedError }
+    it { expect { subject.opera_system }.to raise_error NotImplementedError }
+    it { expect { subject.distribution_name }.to raise_error NotImplementedError }
+    it { expect { subject.info }.to raise_error NotImplementedError }
+    it { expect { subject.icons }.to raise_error NotImplementedError }
+    it { expect { subject.stored? }.to raise_error NotImplementedError }
+    it { expect { subject.mobileprovision_path }.to raise_error NotImplementedError }
+    it { expect { subject.info_path }.to raise_error NotImplementedError }
+    it { expect { subject.app_path }.to raise_error NotImplementedError }
+    it { expect { subject.mobileprovision_path }.to raise_error NotImplementedError }
+    it { expect { subject.clear! }.to raise_error NotImplementedError }
+  end
+end

--- a/spec/app_info/const_spec.rb
+++ b/spec/app_info/const_spec.rb
@@ -1,0 +1,26 @@
+describe AppInfo::Platform do
+  it { expect(AppInfo::Platform::APPLE).to eq :apple }
+  it { expect(AppInfo::Platform::GOOGLE).to eq :google }
+  it { expect(AppInfo::Platform::WINDOWS).to eq :windows }
+end
+
+describe AppInfo::OperaSystem do
+  it { expect(AppInfo::OperaSystem::MACOS).to eq :macos }
+  it { expect(AppInfo::OperaSystem::IOS).to eq :ios }
+  it { expect(AppInfo::OperaSystem::ANDROID).to eq :android }
+  it { expect(AppInfo::OperaSystem::WINDOWS).to eq :windows }
+end
+
+describe AppInfo::Device do
+  it { expect(AppInfo::Device::MACOS).to eq :macos }
+  it { expect(AppInfo::Device::IPHONE).to eq :iphone }
+  it { expect(AppInfo::Device::IPAD).to eq :ipad }
+  it { expect(AppInfo::Device::IWATCH).to eq :iwatch }
+  it { expect(AppInfo::Device::UNIVERSAL).to eq :universal }
+  it { expect(AppInfo::Device::PHONE).to eq :phone }
+  it { expect(AppInfo::Device::TABLET).to eq :tablet }
+  it { expect(AppInfo::Device::WATCH).to eq :watch }
+  it { expect(AppInfo::Device::TELEVISION).to eq :television }
+  it { expect(AppInfo::Device::AUTOMOTIVE).to eq :automotive }
+  it { expect(AppInfo::Device::WINDOWS).to eq :windows }
+end

--- a/spec/app_info/dsym_spec.rb
+++ b/spec/app_info/dsym_spec.rb
@@ -15,8 +15,12 @@ describe AppInfo::DSYM do
       after { subject.clear! }
       context  do
         it { expect(subject.file).to eq fixture_path('dsyms/iOS-single-dSYM-with-single-macho.zip') }
-        it { expect(subject.file_type).to eq AppInfo::Format::DSYM }
-        it { expect(subject.file_type).to eq :dsym }
+        it { expect(subject.format).to eq AppInfo::Format::DSYM }
+        it { expect(subject.format).to eq :dsym }
+        it { expect(subject.platform).to eq(AppInfo::Platform::APPLE) }
+        it { expect(subject.platform).to eq(:apple) }
+        it { expect{ subject.opera_system }.to raise_error NotImplementedError }
+        it { expect{ subject.device }.to raise_error NotImplementedError }
         it { expect(subject.files.size).to eq 1 }
         it { expect(subject.files[0].object).to eq 'iOS' }
         it { expect(subject.files[0].macho_type).to be_a ::MachO::MachOFile }
@@ -61,8 +65,12 @@ describe AppInfo::DSYM do
 
       context '.parse' do
         it { expect(subject.file).to eq fixture_path('dsyms/iOS-single-dSYM-with-multi-macho.zip') }
-        it { expect(subject.file_type).to eq AppInfo::Format::DSYM }
-        it { expect(subject.file_type).to eq :dsym }
+        it { expect(subject.format).to eq AppInfo::Format::DSYM }
+        it { expect(subject.format).to eq :dsym }
+        it { expect(subject.platform).to eq(AppInfo::Platform::APPLE) }
+        it { expect(subject.platform).to eq(:apple) }
+        it { expect{ subject.opera_system }.to raise_error NotImplementedError }
+        it { expect{ subject.device }.to raise_error NotImplementedError }
         it { expect(subject.files.size).to eq 1 }
         it { expect(subject.files[0].object).to eq 'iOS' }
         it { expect(subject.files[0].macho_type).to be_a ::MachO::FatFile }
@@ -118,8 +126,12 @@ describe AppInfo::DSYM do
 
       context  do
         it { expect(subject.file).to eq file }
-        it { expect(subject.file_type).to eq AppInfo::Format::DSYM }
-        it { expect(subject.file_type).to eq :dsym }
+        it { expect(subject.format).to eq AppInfo::Format::DSYM }
+        it { expect(subject.format).to eq :dsym }
+        it { expect(subject.platform).to eq(AppInfo::Platform::APPLE) }
+        it { expect(subject.platform).to eq(:apple) }
+        it { expect{ subject.opera_system }.to raise_error NotImplementedError }
+        it { expect{ subject.device }.to raise_error NotImplementedError }
         it { expect(subject.files.size).to eq 2 }
         it { expect(subject.files[0].object).to eq 'AppInfo' }
         it { expect(subject.files[0].macho_type).to be_a ::MachO::MachOFile }
@@ -181,8 +193,12 @@ describe AppInfo::DSYM do
 
       context  do
         it { expect(subject.file).to eq file }
-        it { expect(subject.file_type).to eq AppInfo::Format::DSYM }
-        it { expect(subject.file_type).to eq :dsym }
+        it { expect(subject.format).to eq AppInfo::Format::DSYM }
+        it { expect(subject.format).to eq :dsym }
+        it { expect(subject.platform).to eq(AppInfo::Platform::APPLE) }
+        it { expect(subject.platform).to eq(:apple) }
+        it { expect{ subject.opera_system }.to raise_error NotImplementedError }
+        it { expect{ subject.device }.to raise_error NotImplementedError }
         it { expect(subject.files.size).to eq 2 }
         it { expect(subject.files[0].object).to eq 'AppInfo' }
         it { expect(subject.files[0].macho_type).to be_a ::MachO::MachOFile }
@@ -217,51 +233,5 @@ describe AppInfo::DSYM do
 
       after { subject.clear! }
     end
-
-    # context 'when dSYM in root path' do
-    #   subject { AppInfo::DSYM.new(fixture_path('iOS-mutli-dSYMs-directly.zip')) }
-    #   data = [
-    #     {
-    #       type: :dsym,
-    #       uuid: '26dfc15d-bdce-351f-b5de-6ee9f5dd6d85',
-    #       cpu_type: :arm,
-    #       cpu_name: :armv7,
-    #       size: 866_526,
-    #       human_size: '846.22 KB'
-    #     },
-    #     {
-    #       type: :dsym,
-    #       uuid: '17f58291-dd25-3fc8-9417-ccbe8163d33e',
-    #       cpu_type: :arm64,
-    #       cpu_name: :arm64,
-    #       size: 866_911,
-    #       human_size: '846.59 KB'
-    #     }
-    #   ]
-
-    #   it { expect(subject.file_type).to eq AppInfo::Format::DSYM }
-    #   it { expect(subject.file_type).to eq :dsym }
-    #   it { expect(subject.object).to eq 'iOS' }
-    #   it { expect(subject.macho_type).to be_a ::MachO::FatFile }
-    #   it { expect(subject.release_version).to eq '1.0' }
-    #   it { expect(subject.build_version).to eq '2' }
-    #   it { expect(subject.identifier).to eq 'com.icyleaf.iOS' }
-    #   it { expect(subject.bundle_id).to eq 'com.icyleaf.iOS' }
-    #   it { expect(subject.machos.size).to eq 2 }
-    #   it { expect(subject.machos[0].type).to eq data[0][:type] }
-    #   it { expect(subject.machos[0].uuid).to eq data[0][:uuid] }
-    #   it { expect(subject.machos[0].cpu_type).to eq data[0][:cpu_type] }
-    #   it { expect(subject.machos[0].cpu_name).to eq data[0][:cpu_name] }
-    #   it { expect(subject.machos[0].size).to eq data[0][:size] }
-    #   it { expect(subject.machos[0].size(human_size: true)).to eq data[0][:human_size] }
-    #   it { expect(subject.machos[0].to_h).to eq data[0] }
-    #   it { expect(subject.machos[1].type).to eq data[1][:type] }
-    #   it { expect(subject.machos[1].uuid).to eq data[1][:uuid] }
-    #   it { expect(subject.machos[1].cpu_type).to eq data[1][:cpu_type] }
-    #   it { expect(subject.machos[1].cpu_name).to eq data[1][:cpu_name] }
-    #   it { expect(subject.machos[1].size).to eq data[1][:size] }
-    #   it { expect(subject.machos[1].size(human_size: true)).to eq data[1][:human_size] }
-    #   it { expect(subject.machos[1].to_h).to eq data[1] }
-    # end
   end
 end

--- a/spec/app_info/file_spec.rb
+++ b/spec/app_info/file_spec.rb
@@ -4,7 +4,10 @@ describe AppInfo::File do
     subject { AppInfo::File.new(file) }
 
     context 'parse' do
-      it { expect{ subject.file_type }.to raise_error NotImplementedError }
+      it { expect{ subject.format }.to raise_error NotImplementedError }
+      it { expect{ subject.platform }.to raise_error NotImplementedError }
+      it { expect{ subject.opera_system }.to raise_error NotImplementedError }
+      it { expect{ subject.device }.to raise_error NotImplementedError }
       it { expect{ subject.size }.to raise_error NotImplementedError }
     end
   end

--- a/spec/app_info/file_spec.rb
+++ b/spec/app_info/file_spec.rb
@@ -1,0 +1,11 @@
+describe AppInfo::File do
+  context 'when ininizlize' do
+    let(:file) { fixture_path('apps/win-TopBar-v0.1.1.zip') }
+    subject { AppInfo::File.new(file) }
+
+    context 'parse' do
+      it { expect{ subject.file_type }.to raise_error NotImplementedError }
+      it { expect{ subject.size }.to raise_error NotImplementedError }
+    end
+  end
+end

--- a/spec/app_info/info_plist_spec.rb
+++ b/spec/app_info/info_plist_spec.rb
@@ -1,11 +1,54 @@
 describe AppInfo::InfoPlist do
-  context 'when iOS' do
+  context 'when iPhone' do
+    let(:app) { AppInfo::IPA.new(fixture_path('apps/iphone.ipa')) }
+    subject { AppInfo::InfoPlist.new(app.info_path) }
+
+    it { expect(subject.format).to eq AppInfo::Format::INFOPLIST }
+    it { expect(subject.format).to eq :infoplist }
+    it { expect(subject.platform).to eq(AppInfo::Platform::APPLE) }
+    it { expect(subject.platform).to eq(:apple) }
+    it { expect(subject.opera_system).to eq(AppInfo::OperaSystem::IOS) }
+    it { expect(subject.opera_system).to eq(:ios) }
+    it { expect(subject.device).to eq(AppInfo::Device::IPHONE) }
+    it { expect(subject.device).to eq(:iphone) }
+    it { expect(subject).to be_iphone }
+    it { expect(subject).not_to be_ipad }
+    it { expect(subject).not_to be_universal }
+    it { expect(subject).not_to be_macos }
+    it { expect(subject.build_version).to eq('5') }
+    it { expect(subject.release_version).to eq('1.2.3') }
+    it { expect(subject.name).to eq('AppInfoDemo') }
+    it { expect(subject.bundle_name).to eq('AppInfoDemo') }
+    it { expect(subject.display_name).to be_nil }
+    it { expect(subject.identifier).to eq('com.icyleaf.AppInfoDemo') }
+    it { expect(subject.bundle_id).to eq('com.icyleaf.AppInfoDemo') }
+    it { expect(subject.min_sdk_version).to eq('9.3') }
+    it { expect(subject.min_os_version).to eq('9.3') }
+
+    it { expect(subject.to_h).to be_a Hash }
+    it { expect(subject['CFBundleVersion']).to eq('5') }
+    it { expect(subject[:CFBundleShortVersionString]).to eq('1.2.3') }
+    it { expect(subject.CFBundleShortVersionString).to eq('1.2.3') }
+    it { expect(subject.c_f_bundle_short_version_string).to eq('1.2.3') }
+    it { expect(subject.icons).to be_kind_of Array }
+  end
+
+  context 'when iPad' do
     let(:app) { AppInfo::IPA.new(fixture_path('apps/ipad.ipa')) }
     subject { AppInfo::InfoPlist.new(app.info_path) }
 
-    it { expect(subject.file_type).to eq(AppInfo::Format::INFOPLIST) }
-    it { expect(subject.file_type).to eq(:infoplist) }
-    it { expect(subject.build_version).to eq('1') }
+    it { expect(subject.format).to eq AppInfo::Format::INFOPLIST }
+    it { expect(subject.format).to eq :infoplist }
+    it { expect(subject.platform).to eq(AppInfo::Platform::APPLE) }
+    it { expect(subject.platform).to eq(:apple) }
+    it { expect(subject.opera_system).to eq(AppInfo::OperaSystem::IOS) }
+    it { expect(subject.opera_system).to eq(:ios) }
+    it { expect(subject.device).to eq(AppInfo::Device::IPAD) }
+    it { expect(subject.device).to eq(:ipad) }
+    it { expect(subject).not_to be_iphone }
+    it { expect(subject).to be_ipad }
+    it { expect(subject).not_to be_universal }
+    it { expect(subject).not_to be_macos }
     it { expect(subject.build_version).to eq('1') }
     it { expect(subject.release_version).to eq('1.0') }
     it { expect(subject.name).to eq('bundle') }
@@ -13,9 +56,42 @@ describe AppInfo::InfoPlist do
     it { expect(subject.display_name).to be_nil }
     it { expect(subject.identifier).to eq('com.icyleaf.bundle') }
     it { expect(subject.bundle_id).to eq('com.icyleaf.bundle') }
-    it { expect(subject.device_type).to eq('iPad') }
     it { expect(subject.min_sdk_version).to eq('9.3') }
     it { expect(subject.min_os_version).to eq('9.3') }
+
+    it { expect(subject.to_h).to be_a Hash }
+    it { expect(subject['CFBundleVersion']).to eq('1') }
+    it { expect(subject[:CFBundleShortVersionString]).to eq('1.0') }
+    it { expect(subject.CFBundleShortVersionString).to eq('1.0') }
+    it { expect(subject.c_f_bundle_short_version_string).to eq('1.0') }
+    it { expect(subject.icons).to be_kind_of Array }
+  end
+
+  context 'when Unversal of iOS' do
+    let(:app) { AppInfo::IPA.new(fixture_path('apps/embedded.ipa')) }
+    subject { AppInfo::InfoPlist.new(app.info_path) }
+
+    it { expect(subject.format).to eq AppInfo::Format::INFOPLIST }
+    it { expect(subject.format).to eq :infoplist }
+    it { expect(subject.platform).to eq(AppInfo::Platform::APPLE) }
+    it { expect(subject.platform).to eq(:apple) }
+    it { expect(subject.opera_system).to eq(AppInfo::OperaSystem::IOS) }
+    it { expect(subject.opera_system).to eq(:ios) }
+    it { expect(subject.device).to eq(AppInfo::Device::UNIVERSAL) }
+    it { expect(subject.device).to eq(:universal) }
+    it { expect(subject).not_to be_iphone }
+    it { expect(subject).not_to be_ipad }
+    it { expect(subject).to be_universal }
+    it { expect(subject).not_to be_macos }
+    it { expect(subject.build_version).to eq('1') }
+    it { expect(subject.release_version).to eq('1.0') }
+    it { expect(subject.name).to eq('Demo') }
+    it { expect(subject.bundle_name).to eq('Demo') }
+    it { expect(subject.display_name).to be_nil }
+    it { expect(subject.identifier).to eq('com.icyleaf.test.Demo') }
+    it { expect(subject.bundle_id).to eq('com.icyleaf.test.Demo') }
+    it { expect(subject.min_sdk_version).to eq('14.3') }
+    it { expect(subject.min_os_version).to eq('14.3') }
 
     it { expect(subject.to_h).to be_a Hash }
     it { expect(subject['CFBundleVersion']).to eq('1') }
@@ -29,8 +105,18 @@ describe AppInfo::InfoPlist do
     let(:app) { AppInfo::Macos.new(fixture_path('apps/macos.zip')) }
     subject { AppInfo::InfoPlist.new(app.info_path) }
 
-    it { expect(subject.file_type).to eq(AppInfo::Format::INFOPLIST) }
-    it { expect(subject.file_type).to eq(:infoplist) }
+    it { expect(subject.format).to eq AppInfo::Format::INFOPLIST }
+    it { expect(subject.format).to eq :infoplist }
+    it { expect(subject.platform).to eq(AppInfo::Platform::APPLE) }
+    it { expect(subject.platform).to eq(:apple) }
+    it { expect(subject.opera_system).to eq(AppInfo::OperaSystem::MACOS) }
+    it { expect(subject.opera_system).to eq(:macos) }
+    it { expect(subject.device).to eq(AppInfo::Device::MACOS) }
+    it { expect(subject.device).to eq(:macos) }
+    it { expect(subject).not_to be_iphone }
+    it { expect(subject).not_to be_ipad }
+    it { expect(subject).not_to be_universal }
+    it { expect(subject).to be_macos }
     it { expect(subject.build_version).to eq('1') }
     it { expect(subject.release_version).to eq('1.0') }
     it { expect(subject.name).to eq('GuiApp') }
@@ -38,10 +124,8 @@ describe AppInfo::InfoPlist do
     it { expect(subject.display_name).to be_nil }
     it { expect(subject.identifier).to eq('com.icyleaf.macos.GUIApp') }
     it { expect(subject.bundle_id).to eq('com.icyleaf.macos.GUIApp') }
-    it { expect(subject.device_type).to eq('macOS') }
     it { expect(subject.min_system_version).to eq('11.3') }
     it { expect(subject.min_os_version).to eq('11.3') }
-
     it { expect(subject.to_h).to be_a Hash }
     it { expect(subject['CFBundleVersion']).to eq('1') }
     it { expect(subject[:CFBundleShortVersionString]).to eq('1.0') }
@@ -49,18 +133,4 @@ describe AppInfo::InfoPlist do
     it { expect(subject.c_f_bundle_short_version_string).to eq('1.0') }
     it { expect(subject.icons).to be_kind_of Array }
   end
-
-  # context ".icons" do
-  #   it "should uncrush icons" do
-  #     subject.icons.each do |icon|
-  #       expect(icon[:uncrushed_file]).not_to be_nil
-  #     end
-  #   end
-
-  #   it "should not return uncrushed icons" do
-  #     subject.icons(false).each do |icon|
-  #       expect(icon[:uncrushed_file]).to be_nil
-  #     end
-  #   end
-  # end
 end

--- a/spec/app_info/ipa_spec.rb
+++ b/spec/app_info/ipa_spec.rb
@@ -31,8 +31,8 @@ describe AppInfo::IPA do
     it { expect(subject.icons).to be_kind_of Array }
     it { expect(subject.icons).to be_empty }
 
-    it { expect(subject.release_type).to eq('AdHoc') }
-    it { expect(subject.build_type).to eq('AdHoc') }
+    it { expect(subject.release_type).to eq(:adhoc) }
+    it { expect(subject.build_type).to eq(:adhoc) }
     it { expect(subject.devices).to be_kind_of Array }
     it { expect(subject.team_name).to eq('QYER Inc') }
     it { expect(subject.profile_name).to eq('iOS Team Provisioning Profile: *') }
@@ -82,8 +82,8 @@ describe AppInfo::IPA do
     it { expect(subject.icons).to be_kind_of Array }
     it { expect(subject.icons).not_to be_empty }
 
-    it { expect(subject.release_type).to eq('Enterprise') }
-    it { expect(subject.build_type).to eq('Enterprise') }
+    it { expect(subject.release_type).to eq(:enterprise) }
+    it { expect(subject.build_type).to eq(:enterprise) }
     it { expect(subject.devices).to be_nil }
     it { expect(subject.team_name).to eq('QYER Inc') }
     it { expect(subject.profile_name).to eq('XC: *') }
@@ -140,8 +140,8 @@ describe AppInfo::IPA do
     it { expect(subject.bundle_id).to eq('com.icyleaf.test.Demo') }
     it { expect(subject.archs).to eq(%i[arm64]) }
 
-    it { expect(subject.release_type).to eq('Enterprise') }
-    it { expect(subject.build_type).to eq('Enterprise') }
+    it { expect(subject.release_type).to eq(:enterprise) }
+    it { expect(subject.build_type).to eq(:enterprise) }
     it { expect(subject.devices).to be_nil }
 
     it { expect(subject.mobileprovision?).to be true }

--- a/spec/app_info/ipa_spec.rb
+++ b/spec/app_info/ipa_spec.rb
@@ -5,50 +5,51 @@ describe AppInfo::IPA do
 
     after { subject.clear! }
 
-    context 'parse' do
-      it { expect(subject.file_type).to eq AppInfo::Format::IPA }
-      it { expect(subject.file_type).to eq :ipa }
-      it { expect(subject.platform).to eq 'iOS' }
-      it { expect(subject.platform).to eq AppInfo::Platform::IOS }
-      it { expect(subject).to be_iphone }
-      it { expect(subject).not_to be_ipad }
-      it { expect(subject).not_to be_universal }
-      it { expect(subject.file).to eq file }
-      it { expect(subject.build_version).to eq('5') }
-      it { expect(subject.release_version).to eq('1.2.3') }
-      it { expect(subject.name).to eq('AppInfoDemo') }
-      it { expect(subject.bundle_name).to eq('AppInfoDemo') }
-      it { expect(subject.display_name).to be_nil }
-      it { expect(subject.identifier).to eq('com.icyleaf.AppInfoDemo') }
-      it { expect(subject.bundle_id).to eq('com.icyleaf.AppInfoDemo') }
-      it { expect(subject.device_type).to eq('iPhone') }
-      it { expect(subject.min_sdk_version).to eq('9.3') }
-      it { expect(subject.info['CFBundleVersion']).to eq('5') }
-      it { expect(subject.info[:CFBundleShortVersionString]).to eq('1.2.3') }
-      it { expect(subject.archs).to eq(%i[armv7 arm64]) }
-      it { expect(subject.icons).to be_kind_of Array }
-      it { expect(subject.icons).to be_empty }
+    it { expect(subject.file).to eq file }
+    it { expect(subject.format).to eq AppInfo::Format::IPA }
+    it { expect(subject.format).to eq :ipa }
+    it { expect(subject.platform).to eq(AppInfo::Platform::APPLE) }
+    it { expect(subject.platform).to eq(:apple) }
+    it { expect(subject.opera_system).to eq(AppInfo::OperaSystem::IOS) }
+    it { expect(subject.opera_system).to eq(:ios) }
+    it { expect(subject.device).to eq(AppInfo::Device::IPHONE) }
+    it { expect(subject.device).to eq(:iphone) }
+    it { expect(subject).to be_iphone }
+    it { expect(subject).not_to be_ipad }
+    it { expect(subject).not_to be_universal }
+    it { expect(subject.build_version).to eq('5') }
+    it { expect(subject.release_version).to eq('1.2.3') }
+    it { expect(subject.name).to eq('AppInfoDemo') }
+    it { expect(subject.bundle_name).to eq('AppInfoDemo') }
+    it { expect(subject.display_name).to be_nil }
+    it { expect(subject.identifier).to eq('com.icyleaf.AppInfoDemo') }
+    it { expect(subject.bundle_id).to eq('com.icyleaf.AppInfoDemo') }
+    it { expect(subject.min_sdk_version).to eq('9.3') }
+    it { expect(subject.info['CFBundleVersion']).to eq('5') }
+    it { expect(subject.info[:CFBundleShortVersionString]).to eq('1.2.3') }
+    it { expect(subject.archs).to eq(%i[armv7 arm64]) }
+    it { expect(subject.icons).to be_kind_of Array }
+    it { expect(subject.icons).to be_empty }
 
-      it { expect(subject.release_type).to eq('AdHoc') }
-      it { expect(subject.build_type).to eq('AdHoc') }
-      it { expect(subject.devices).to be_kind_of Array }
-      it { expect(subject.team_name).to eq('QYER Inc') }
-      it { expect(subject.profile_name).to eq('iOS Team Provisioning Profile: *') }
-      it { expect(subject.expired_date).not_to be_nil }
-      it { expect(subject.distribution_name).not_to be_nil }
+    it { expect(subject.release_type).to eq('AdHoc') }
+    it { expect(subject.build_type).to eq('AdHoc') }
+    it { expect(subject.devices).to be_kind_of Array }
+    it { expect(subject.team_name).to eq('QYER Inc') }
+    it { expect(subject.profile_name).to eq('iOS Team Provisioning Profile: *') }
+    it { expect(subject.expired_date).not_to be_nil }
+    it { expect(subject.distribution_name).not_to be_nil }
 
-      it { expect(subject.mobileprovision?).to be true }
-      it { expect(subject.mobileprovision.certificates[0]).to be_kind_of AppInfo::Certificate }
+    it { expect(subject.mobileprovision?).to be true }
+    it { expect(subject.mobileprovision.certificates[0]).to be_kind_of AppInfo::Certificate }
 
-      it { expect(subject.metadata).to be_nil }
-      it { expect(subject.metadata?).to be false }
-      it { expect(subject.stored?).to be false }
-      it { expect(subject.info).to be_kind_of AppInfo::InfoPlist }
-      it { expect(subject.mobileprovision).to be_kind_of AppInfo::MobileProvision }
+    it { expect(subject.metadata).to be_nil }
+    it { expect(subject.metadata?).to be false }
+    it { expect(subject.stored?).to be false }
+    it { expect(subject.info).to be_kind_of AppInfo::InfoPlist }
+    it { expect(subject.mobileprovision).to be_kind_of AppInfo::MobileProvision }
 
-      it { expect(subject.plugins).to be_empty }
-      it { expect(subject.frameworks).to be_empty }
-    end
+    it { expect(subject.plugins).to be_empty }
+    it { expect(subject.frameworks).to be_empty }
   end
 
   describe '#iPad' do
@@ -57,14 +58,18 @@ describe AppInfo::IPA do
 
     after { subject.clear! }
 
-    it { expect(subject.file_type).to eq AppInfo::Format::IPA }
-    it { expect(subject.file_type).to eq :ipa }
-    it { expect(subject.platform).to eq 'iOS' }
-    it { expect(subject.platform).to eq AppInfo::Platform::IOS }
+    it { expect(subject.file).to eq file }
+    it { expect(subject.format).to eq AppInfo::Format::IPA }
+    it { expect(subject.format).to eq :ipa }
+    it { expect(subject.platform).to eq(AppInfo::Platform::APPLE) }
+    it { expect(subject.platform).to eq(:apple) }
+    it { expect(subject.opera_system).to eq(AppInfo::OperaSystem::IOS) }
+    it { expect(subject.opera_system).to eq(:ios) }
+    it { expect(subject.device).to eq(AppInfo::Device::IPAD) }
+    it { expect(subject.device).to eq(:ipad) }
     it { expect(subject).not_to be_iphone }
     it { expect(subject).to be_ipad }
     it { expect(subject).not_to be_universal }
-    it { expect(subject.file).to eq file }
     it { expect(subject.build_version).to eq('1') }
     it { expect(subject.release_version).to eq('1.0') }
     it { expect(subject.min_sdk_version).to eq('9.3') }
@@ -73,7 +78,6 @@ describe AppInfo::IPA do
     it { expect(subject.display_name).to be_nil }
     it { expect(subject.identifier).to eq('com.icyleaf.bundle') }
     it { expect(subject.bundle_id).to eq('com.icyleaf.bundle') }
-    it { expect(subject.device_type).to eq('iPad') }
     it { expect(subject.archs).to eq(%i[armv7 arm64]) }
     it { expect(subject.icons).to be_kind_of Array }
     it { expect(subject.icons).not_to be_empty }
@@ -108,20 +112,24 @@ describe AppInfo::IPA do
     it { expect(subject.frameworks).to be_empty }
   end
 
-  describe '#Embedded' do
+  describe '#Universal' do
     let(:file) { fixture_path('apps/embedded.ipa') }
     subject { AppInfo::IPA.new(file) }
 
     after { subject.clear! }
 
-    it { expect(subject.file_type).to eq AppInfo::Format::IPA }
-    it { expect(subject.file_type).to eq :ipa }
-    it { expect(subject.platform).to eq 'iOS' }
-    it { expect(subject.platform).to eq AppInfo::Platform::IOS }
-    it { expect(subject).not_to be_iphone }
-    it { expect(subject).not_to be_iphone }
-    it { expect(subject).to be_universal }
     it { expect(subject.file).to eq file }
+    it { expect(subject.format).to eq AppInfo::Format::IPA }
+    it { expect(subject.format).to eq :ipa }
+    it { expect(subject.platform).to eq(AppInfo::Platform::APPLE) }
+    it { expect(subject.platform).to eq(:apple) }
+    it { expect(subject.opera_system).to eq(AppInfo::OperaSystem::IOS) }
+    it { expect(subject.opera_system).to eq(:ios) }
+    it { expect(subject.device).to eq(AppInfo::Device::UNIVERSAL) }
+    it { expect(subject.device).to eq(:universal) }
+    it { expect(subject).not_to be_iphone }
+    it { expect(subject).not_to be_ipad }
+    it { expect(subject).to be_universal }
     it { expect(subject.build_version).to eq('1') }
     it { expect(subject.release_version).to eq('1.0') }
     it { expect(subject.min_sdk_version).to eq('14.3') }
@@ -130,7 +138,6 @@ describe AppInfo::IPA do
     it { expect(subject.display_name).to be_nil }
     it { expect(subject.identifier).to eq('com.icyleaf.test.Demo') }
     it { expect(subject.bundle_id).to eq('com.icyleaf.test.Demo') }
-    it { expect(subject.device_type).to eq('Universal') }
     it { expect(subject.archs).to eq(%i[arm64]) }
 
     it { expect(subject.release_type).to eq('Enterprise') }

--- a/spec/app_info/macos_spec.rb
+++ b/spec/app_info/macos_spec.rb
@@ -28,7 +28,7 @@ describe AppInfo::Macos do
         it { expect(subject.info['CFBundleVersion']).to eq('1') }
         it { expect(subject.info[:CFBundleShortVersionString]).to eq('1.0') }
         it { expect(subject.archs).to eq(%i[x86_64 arm64]) }
-        it { expect(subject.release_type).to eq('Debug') }
+        it { expect(subject.release_type).to eq(:debug) }
         it { expect(subject.mobileprovision?).to be false }
         it { expect(subject.stored?).to be false }
         it { expect(subject.info).to be_kind_of AppInfo::InfoPlist }
@@ -72,7 +72,7 @@ describe AppInfo::Macos do
         it { expect(subject.info['CFBundleVersion']).to eq('1') }
         it { expect(subject.info[:CFBundleShortVersionString]).to eq('1.0') }
         it { expect(subject.archs).to eq(%i[x86_64 arm64]) }
-        it { expect(subject.release_type).to eq('Release') }
+        it { expect(subject.release_type).to eq(:release) }
         it { expect(subject.stored?).to be false }
         it { expect(subject.info).to be_kind_of AppInfo::InfoPlist }
         it { expect(subject.mobileprovision).to be_kind_of AppInfo::MobileProvision }

--- a/spec/app_info/macos_spec.rb
+++ b/spec/app_info/macos_spec.rb
@@ -7,15 +7,15 @@ describe AppInfo::Macos do
       after { subject.clear! }
 
       context 'parse' do
-        it { expect(subject.file_type).to eq AppInfo::Format::MACOS }
-        it { expect(subject.file_type).to eq :macos }
-        it { expect(subject.platform).to eq AppInfo::Platform::MACOS }
-        it { expect(subject.platform).to eq 'macOS' }
-        it { expect(subject).to be_macos }
-        it { expect(subject).not_to be_iphone }
-        it { expect(subject).not_to be_ipad }
-        it { expect(subject).not_to be_universal }
         it { expect(subject.file).to eq file }
+        it { expect(subject.format).to eq AppInfo::Format::MACOS }
+        it { expect(subject.format).to eq :macos }
+        it { expect(subject.platform).to eq(AppInfo::Platform::APPLE) }
+        it { expect(subject.platform).to eq(:apple) }
+        it { expect(subject.opera_system).to eq(AppInfo::OperaSystem::MACOS) }
+        it { expect(subject.opera_system).to eq(:macos) }
+        it { expect(subject.device).to eq(AppInfo::Device::MACOS) }
+        it { expect(subject.device).to eq(:macos) }
         it { expect(subject.build_version).to eq('1') }
         it { expect(subject.release_version).to eq('1.0') }
         it { expect(subject.name).to eq('GuiApp') }
@@ -23,7 +23,6 @@ describe AppInfo::Macos do
         it { expect(subject.display_name).to be_nil }
         it { expect(subject.identifier).to eq('com.icyleaf.macos.GUIApp') }
         it { expect(subject.bundle_id).to eq('com.icyleaf.macos.GUIApp') }
-        it { expect(subject.device_type).to eq(AppInfo::Device::MACOS) }
         it { expect(subject.min_os_version).to eq('11.3') }
         it { expect(subject.min_system_version).to eq('11.3') }
         it { expect(subject.info['CFBundleVersion']).to eq('1') }
@@ -52,15 +51,15 @@ describe AppInfo::Macos do
       after { subject.clear! }
 
       context 'parse' do
-        it { expect(subject.file_type).to eq AppInfo::Format::MACOS }
-        it { expect(subject.file_type).to eq :macos }
-        it { expect(subject.platform).to eq AppInfo::Platform::MACOS }
-        it { expect(subject.platform).to eq 'macOS' }
-        it { expect(subject).to be_macos }
-        it { expect(subject).not_to be_iphone }
-        it { expect(subject).not_to be_ipad }
-        it { expect(subject).not_to be_universal }
         it { expect(subject.file).to eq file }
+        it { expect(subject.format).to eq AppInfo::Format::MACOS }
+        it { expect(subject.format).to eq :macos }
+        it { expect(subject.platform).to eq(AppInfo::Platform::APPLE) }
+        it { expect(subject.platform).to eq(:apple) }
+        it { expect(subject.opera_system).to eq(AppInfo::OperaSystem::MACOS) }
+        it { expect(subject.opera_system).to eq(:macos) }
+        it { expect(subject.device).to eq(AppInfo::Device::MACOS) }
+        it { expect(subject.device).to eq(:macos) }
         it { expect(subject.build_version).to eq('1') }
         it { expect(subject.release_version).to eq('1.0') }
         it { expect(subject.name).to eq('GuiApp') }
@@ -68,7 +67,6 @@ describe AppInfo::Macos do
         it { expect(subject.display_name).to be_nil }
         it { expect(subject.identifier).to eq('com.icyleaf.macos.GUIApp') }
         it { expect(subject.bundle_id).to eq('com.icyleaf.macos.GUIApp') }
-        it { expect(subject.device_type).to eq(AppInfo::Device::MACOS) }
         it { expect(subject.min_os_version).to eq('11.3') }
         it { expect(subject.min_system_version).to eq('11.3') }
         it { expect(subject.info['CFBundleVersion']).to eq('1') }

--- a/spec/app_info/mobile_provision_spec.rb
+++ b/spec/app_info/mobile_provision_spec.rb
@@ -3,11 +3,15 @@ describe AppInfo::MobileProvision do
     context 'Development' do
       subject { AppInfo::MobileProvision.new(fixture_path('mobileprovisions/ios_development.mobileprovision')) }
 
-      it { expect(subject.file_type).to eq AppInfo::Format::MOBILEPROVISION }
-      it { expect(subject.file_type).to eq :mobileprovision }
-      it { expect(subject.devices).to be_a Array }
-      it { expect(subject.platform).to eq :ios }
-      it { expect(subject.platforms).to eq [:ios] }
+      it { expect(subject.format).to eq AppInfo::Format::MOBILEPROVISION }
+      it { expect(subject.format).to eq :mobileprovision }
+      it { expect(subject.platform).to eq AppInfo::Platform::APPLE }
+      it { expect(subject.platform).to eq :apple }
+      it { expect(subject.opera_system).to eq AppInfo::OperaSystem::IOS }
+      it { expect(subject.opera_system).to eq :ios }
+      it { expect(subject.opera_systems).to eq [:ios] }
+      it { expect{ subject.device }.to raise_error NotImplementedError }
+      it { expect(subject.devices).to eq(['e801228c2086d3aacc917b9c3d19bfa56efcab5b']) }
       it { expect(subject.name).to_not be_empty }
       it { expect(subject.app_name).to_not be_empty }
       it { expect(subject.type).to eq :development }
@@ -32,11 +36,18 @@ describe AppInfo::MobileProvision do
     context 'Adhoc' do
       subject { AppInfo::MobileProvision.new(fixture_path('mobileprovisions/ios_adhoc.mobileprovision')) }
 
-      it { expect(subject.file_type).to eq AppInfo::Format::MOBILEPROVISION }
-      it { expect(subject.file_type).to eq :mobileprovision }
+      it { expect(subject.format).to eq AppInfo::Format::MOBILEPROVISION }
+      it { expect(subject.format).to eq :mobileprovision }
+      it { expect(subject.platform).to eq AppInfo::Platform::APPLE }
+      it { expect(subject.platform).to eq :apple }
+      it { expect(subject.opera_system).to eq AppInfo::OperaSystem::IOS }
+      it { expect(subject.opera_system).to eq :ios }
+      it { expect(subject.opera_system).to eq AppInfo::OperaSystem::IOS }
+      it { expect(subject.opera_system).to eq :ios }
+      it { expect(subject.opera_systems).to eq [:ios] }
+      it { expect{ subject.device }.to raise_error NotImplementedError }
       it { expect(subject.devices).to be_a Array }
-      it { expect(subject.platform).to eq :ios }
-      it { expect(subject.platforms).to eq [:ios] }
+      it { expect(subject.devices).to eq(['e801228c2086d3aacc917b9c3d19bfa56efcab5b']) }
       it { expect(subject.name).to_not be_empty }
       it { expect(subject.app_name).to_not be_empty }
       it { expect(subject.type).to eq :adhoc }
@@ -58,11 +69,15 @@ describe AppInfo::MobileProvision do
     context 'AppStore' do
       subject { AppInfo::MobileProvision.new(fixture_path('mobileprovisions/ios_appstore.mobileprovision')) }
 
-      it { expect(subject.file_type).to eq AppInfo::Format::MOBILEPROVISION }
-      it { expect(subject.file_type).to eq :mobileprovision }
+      it { expect(subject.format).to eq AppInfo::Format::MOBILEPROVISION }
+      it { expect(subject.format).to eq :mobileprovision }
+      it { expect(subject.platform).to eq AppInfo::Platform::APPLE }
+      it { expect(subject.platform).to eq :apple }
+      it { expect(subject.opera_system).to eq AppInfo::OperaSystem::IOS }
+      it { expect(subject.opera_system).to eq :ios }
+      it { expect(subject.opera_systems).to eq [:ios] }
+      it { expect{ subject.device }.to raise_error NotImplementedError }
       it { expect(subject.devices).to be_nil }
-      it { expect(subject.platform).to eq :ios }
-      it { expect(subject.platforms).to eq [:ios] }
       it { expect(subject.name).to_not be_empty }
       it { expect(subject.app_name).to_not be_empty }
       it { expect(subject.type).to eq :appstore }
@@ -86,11 +101,15 @@ describe AppInfo::MobileProvision do
     context 'Development' do
       subject { AppInfo::MobileProvision.new(fixture_path('mobileprovisions/macos_development.provisionprofile')) }
 
-      it { expect(subject.file_type).to eq AppInfo::Format::MOBILEPROVISION }
-      it { expect(subject.file_type).to eq :mobileprovision }
+      it { expect(subject.format).to eq AppInfo::Format::MOBILEPROVISION }
+      it { expect(subject.format).to eq :mobileprovision }
+      it { expect(subject.platform).to eq AppInfo::Platform::APPLE }
+      it { expect(subject.platform).to eq :apple }
+      it { expect(subject.opera_system).to eq AppInfo::OperaSystem::MACOS }
+      it { expect(subject.opera_system).to eq :macos }
+      it { expect(subject.opera_systems).to eq [:macos] }
+      it { expect{ subject.device }.to raise_error NotImplementedError }
       it { expect(subject.devices).to be_a Array }
-      it { expect(subject.platform).to eq :macos }
-      it { expect(subject.platforms).to eq [:macos] }
       it { expect(subject.name).to_not be_empty }
       it { expect(subject.app_name).to_not be_empty }
       it { expect(subject.type).to eq :development }
@@ -112,11 +131,15 @@ describe AppInfo::MobileProvision do
     context 'AppStore' do
       subject { AppInfo::MobileProvision.new(fixture_path('mobileprovisions/macos_appstore.provisionprofile')) }
 
-      it { expect(subject.file_type).to eq AppInfo::Format::MOBILEPROVISION }
-      it { expect(subject.file_type).to eq :mobileprovision }
+      it { expect(subject.format).to eq AppInfo::Format::MOBILEPROVISION }
+      it { expect(subject.format).to eq :mobileprovision }
+      it { expect(subject.platform).to eq AppInfo::Platform::APPLE }
+      it { expect(subject.platform).to eq :apple }
+      it { expect(subject.opera_system).to eq AppInfo::OperaSystem::MACOS }
+      it { expect(subject.opera_system).to eq :macos }
+      it { expect(subject.opera_systems).to eq [:macos] }
+      it { expect{ subject.device }.to raise_error NotImplementedError }
       it { expect(subject.devices).to be_nil }
-      it { expect(subject.platform).to eq :macos }
-      it { expect(subject.platforms).to eq [:macos] }
       it { expect(subject.name).to_not be_empty }
       it { expect(subject.app_name).to_not be_empty }
       it { expect(subject.type).to eq :appstore }

--- a/spec/app_info/parser_spec.rb
+++ b/spec/app_info/parser_spec.rb
@@ -1,4 +1,0 @@
-describe AppInfo::Platform do
-  it { expect(AppInfo::Platform::IOS).to eq 'iOS' }
-  it { expect(AppInfo::Platform::ANDROID).to eq 'Android' }
-end

--- a/spec/app_info/pe_spec.rb
+++ b/spec/app_info/pe_spec.rb
@@ -1,11 +1,11 @@
 describe AppInfo::PE do
-  context 'when parse a .zip file' do
-    let(:file) { fixture_path('apps/win-TopBar-v0.1.1.zip') }
-    subject { AppInfo::PE.new(file) }
+  describe 'when give a .zip file' do
+    context 'include exe file' do
+      let(:file) { fixture_path('apps/win-TopBar-v0.1.1.zip') }
+      subject { AppInfo::PE.new(file) }
 
-    after { subject.clear! }
+      after { subject.clear! }
 
-    context 'parse' do
       it { expect(subject.file).to eq file }
       it { expect(subject.format).to eq AppInfo::Format::PE }
       it { expect(subject.format).to eq :pe }
@@ -45,6 +45,13 @@ describe AppInfo::PE do
         expect(icons[0][:file]).to end_with "win-TopBar-v0.1.1-ICON-1.bmp"
         expect(icons[0][:dimensions]).to eq([16, 16])
       end
+    end
+
+    context 'exclude exe file' do
+      let(:file) { fixture_path('apps/iphone.ipa') }
+      subject { AppInfo::PE.new(file) }
+
+      it { expect { subject.binary_file }.to raise_error(AppInfo::NotFoundError) }
     end
   end
 

--- a/spec/app_info/pe_spec.rb
+++ b/spec/app_info/pe_spec.rb
@@ -6,11 +6,13 @@ describe AppInfo::PE do
     after { subject.clear! }
 
     context 'parse' do
-      it { expect(subject.file_type).to eq AppInfo::Format::PE }
-      it { expect(subject.file_type).to eq :pe }
-      it { expect(subject.platform).to eq AppInfo::Platform::WINDOWS }
-      it { expect(subject.platform).to eq 'Windows' }
       it { expect(subject.file).to eq file }
+      it { expect(subject.format).to eq AppInfo::Format::PE }
+      it { expect(subject.format).to eq :pe }
+      it { expect(subject.platform).to eq AppInfo::Platform::WINDOWS }
+      it { expect(subject.platform).to eq :windows }
+      it { expect(subject.device).to eq AppInfo::Device::WINDOWS }
+      it { expect(subject.device).to eq :windows }
       it { expect(subject.binary_file).not_to be_nil }
       it { expect(subject.size).to eq 415127 }
       it { expect(subject.size(human_size: true)).to eq "405.40 KB" }
@@ -53,11 +55,13 @@ describe AppInfo::PE do
     after { subject.clear! }
 
     context 'parse' do
-      it { expect(subject.file_type).to eq AppInfo::Format::PE }
-      it { expect(subject.file_type).to eq :pe }
-      it { expect(subject.platform).to eq AppInfo::Platform::WINDOWS }
-      it { expect(subject.platform).to eq 'Windows' }
       it { expect(subject.file).to eq file }
+      it { expect(subject.format).to eq AppInfo::Format::PE }
+      it { expect(subject.format).to eq :pe }
+      it { expect(subject.platform).to eq AppInfo::Platform::WINDOWS }
+      it { expect(subject.platform).to eq :windows }
+      it { expect(subject.device).to eq AppInfo::Device::WINDOWS }
+      it { expect(subject.device).to eq :windows }
       it { expect(subject.binary_file).not_to be_nil }
       it { expect(subject.size).to eq 293888 }
       it { expect(subject.size(human_size: true)).to eq "287.00 KB" }

--- a/spec/app_info/proguard_spec.rb
+++ b/spec/app_info/proguard_spec.rb
@@ -7,8 +7,13 @@ describe AppInfo::Proguard do
     after { subject.clear! }
 
     context 'parse' do
-      it { expect(subject.file_type).to eq AppInfo::Format::PROGUARD }
-      it { expect(subject.file_type).to eq :proguard }
+      it { expect(subject.format).to eq AppInfo::Format::PROGUARD }
+      it { expect(subject.format).to eq :proguard }
+      it { expect(subject.platform).to eq AppInfo::Platform::GOOGLE }
+      it { expect(subject.platform).to eq :google }
+      it { expect(subject.opera_system).to eq AppInfo::OperaSystem::ANDROID }
+      it { expect(subject.opera_system).to eq :android }
+      it { expect{ subject.device }.to raise_error NotImplementedError }
       it { expect(subject.uuid).to eq '81384aeb-4837-5f73-a771-417b4399a483' }
       it { expect(subject.mapping?).to be true }
       it { expect(subject.symbol?).to be false }
@@ -28,8 +33,13 @@ describe AppInfo::Proguard do
     after { subject.clear! }
 
     context 'parse' do
-      it { expect(subject.file_type).to eq AppInfo::Format::PROGUARD }
-      it { expect(subject.file_type).to eq :proguard }
+      it { expect(subject.format).to eq AppInfo::Format::PROGUARD }
+      it { expect(subject.format).to eq :proguard }
+      it { expect(subject.platform).to eq AppInfo::Platform::GOOGLE }
+      it { expect(subject.platform).to eq :google }
+      it { expect(subject.opera_system).to eq AppInfo::OperaSystem::ANDROID }
+      it { expect(subject.opera_system).to eq :android }
+      it { expect{ subject.device }.to raise_error NotImplementedError }
       it { expect(subject.uuid).to eq '81384aeb-4837-5f73-a771-417b4399a483' }
       it { expect(subject.mapping?).to be true }
       it { expect(subject.symbol?).to be true }

--- a/spec/app_info/protobuf/resources_spec.rb
+++ b/spec/app_info/protobuf/resources_spec.rb
@@ -29,8 +29,8 @@ describe AppInfo::Protobuf::Resources do
     it { expect(subject.find('android:color/white').value).to eq('#FFFFFFFF') }
     it { expect(subject.find('android:color/white', locale: 'foobar').value).to eq('#FFFFFFFF') } # default_value
 
-    it { expect(subject.find('unkown')).to be_nil }
-    it { expect(subject.find('unkown/404')).to be_nil }
+    it { expect(subject.find('unknown')).to be_nil }
+    it { expect(subject.find('unknown/404')).to be_nil }
   end
 
   context '.packages' do

--- a/spec/app_info_spec.rb
+++ b/spec/app_info_spec.rb
@@ -53,7 +53,7 @@ describe AppInfo do
         it 'should throwa an exception when not matched' do
           expect do
             AppInfo.parse(path)
-          end.to raise_error(AppInfo::UnknownFileTypeError)
+          end.to raise_error(AppInfo::UnknownFormatError)
         end
       else
         it 'should parse' do
@@ -91,7 +91,7 @@ describe AppInfo do
 
       expect do
         AppInfo.parse(file.path)
-      end.to raise_error(AppInfo::UnknownFileTypeError)
+      end.to raise_error(AppInfo::UnknownFormatError)
     end
   end
 end


### PR DESCRIPTION
- Rebuild new categories `platform`, `opera_system` and `device`. this is a huge breaking changes.
- Change ExportType values type to symbol both IPA and macOS parsers.