### PR TITLE
Reorganize categories again

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 > List all changes before release a new version.
 
+## [3.0.0.beta3] (2023-04-05)
+
+### Changed
+
+- Rename `.platform` to `.manufacturer`, rename `.opera_sytem` to `.platform` for all parsers.
+
+### Fixed
+
+- Minor fixes.
+
 ## [3.0.0.beta2] (2023-04-04)
 
 ### Changed

--- a/lib/app_info/android.rb
+++ b/lib/app_info/android.rb
@@ -23,14 +23,14 @@ module AppInfo
       file_to_human_size(@file, human_size: human_size)
     end
 
-    # @return [Symbol] {Platform}
-    def platform
-      Platform::GOOGLE
+    # @return [Symbol] {Manufacturer}
+    def manufacturer
+      Manufacturer::GOOGLE
     end
 
-    # @return [Symbol] {OperaSystem}
-    def opera_system
-      OperaSystem::ANDROID
+    # @return [Symbol] {Platform}
+    def platform
+      Platform::ANDROID
     end
 
     # @return [Symbol] {Device}

--- a/lib/app_info/apple.rb
+++ b/lib/app_info/apple.rb
@@ -26,9 +26,9 @@ module AppInfo
       APPSTORE = :appstore
     end
 
-    # @return [Symbol] {Platform}
-    def platform
-      Platform::APPLE
+    # @return [Symbol] {Manufacturer}
+    def manufacturer
+      Manufacturer::APPLE
     end
 
     # return file size
@@ -46,8 +46,8 @@ module AppInfo
 
     # @!method device
     #   @see InfoPlist#device
-    # @!method opera_system
-    #   @see InfoPlist#opera_system
+    # @!method platform
+    #   @see InfoPlist#platform
     # @!method iphone?
     #   @see InfoPlist#iphone?
     # @!method ipad?
@@ -72,7 +72,7 @@ module AppInfo
     #   @see InfoPlist#min_sdk_version
     # @!method min_os_version
     #   @see InfoPlist#min_os_version
-    def_delegators :info, :device, :opera_system, :iphone?, :ipad?, :universal?, :macos?,
+    def_delegators :info, :device, :platform, :iphone?, :ipad?, :universal?, :macos?,
                    :build_version, :name, :release_version, :identifier, :bundle_id,
                    :display_name, :bundle_name, :min_sdk_version, :min_os_version
 

--- a/lib/app_info/certificate.rb
+++ b/lib/app_info/certificate.rb
@@ -6,6 +6,7 @@ module AppInfo
   class Certificate
     # Parse Raw data into X509 cerificate wrapper
     # @param [String] certificate raw data
+    # @return [AppInfo::Certificate]
     def self.parse(data)
       cert = OpenSSL::X509::Certificate.new(data)
       new(cert)
@@ -117,18 +118,20 @@ module AppInfo
       end
     end
 
-    # return size of public key
+    # return length of public key
     # @return [Integer]
-    def size
+    # @raise NotImplementedError
+    def length
       case public_key
       when OpenSSL::PKey::RSA
         public_key.n.num_bits
       when OpenSSL::PKey::DSA, OpenSSL::PKey::DH
         public_key.p.num_bits
       when OpenSSL::PKey::EC
-        raise NotImplementedError, "key size for #{public_key.inspect} not implemented"
+        raise NotImplementedError, "key length for #{public_key.inspect} not implemented"
       end
     end
+    alias size length
 
     # return fingerprint of certificate
     # @return [String]
@@ -166,10 +169,8 @@ module AppInfo
       @cert.send(method.to_sym, *args, &block) || super
     end
 
-    def respond_to_missing?(method_name, *args)
-      @cert.key?(method_name.to_sym) ||
-        @cert.respond_to?(method_name) ||
-        super
+    def respond_to_missing?(method, *args)
+      @cert.respond_to?(method.to_sym) || super
     end
   end
 end

--- a/lib/app_info/const.rb
+++ b/lib/app_info/const.rb
@@ -30,14 +30,15 @@ module AppInfo
     UNKNOWN = :unknown
   end
 
-  # Platform
-  module Platform
+  # Manufacturer
+  module Manufacturer
     APPLE = :apple
     GOOGLE = :google
-    WINDOWS = :windows
+    MICROSOFT = :microsoft
   end
 
-  module OperaSystem
+  # Platform
+  module Platform
     MACOS = :macos
     IOS = :ios
     ANDROID = :android

--- a/lib/app_info/dsym.rb
+++ b/lib/app_info/dsym.rb
@@ -7,9 +7,9 @@ module AppInfo
   class DSYM < File
     include Helper::Archive
 
-    # @return [Symbol] {Platform}
-    def platform
-      Platform::APPLE
+    # @return [Symbol] {Manufacturer}
+    def manufacturer
+      Manufacturer::APPLE
     end
 
     def each_file(&block)

--- a/lib/app_info/file.rb
+++ b/lib/app_info/file.rb
@@ -22,13 +22,13 @@ module AppInfo
       }.call
     end
 
-    # @abstract Subclass and override {#opera_system} to implement.
-    def opera_system
+    # @abstract Subclass and override {#platform} to implement.
+    def platform
       not_implemented_error!(__method__)
     end
 
-    # @abstract Subclass and override {#platform} to implement.
-    def platform
+    # @abstract Subclass and override {#manufacturer} to implement.
+    def manufacturer
       not_implemented_error!(__method__)
     end
 

--- a/lib/app_info/info_plist.rb
+++ b/lib/app_info/info_plist.rb
@@ -17,18 +17,18 @@ module AppInfo
       Device::MACOS => %w[CFBundleIconFile CFBundleIconName]
     }.freeze
 
-    # @return [Symbol] {Platform}
-    def platform
-      Platform::APPLE
+    # @return [Symbol] {Manufacturer}
+    def manufacturer
+      Manufacturer::APPLE
     end
 
-    # @return [Symbol] {OperaSystem}
-    def opera_system
+    # @return [Symbol] {Platform}
+    def platform
       case device
       when Device::MACOS
-        OperaSystem::MACOS
+        Platform::MACOS
       when Device::IPHONE, Device::IPAD, Device::UNIVERSAL
-        OperaSystem::IOS
+        Platform::IOS
       end
     end
 
@@ -40,7 +40,7 @@ module AppInfo
         Device::IPAD
       elsif device_family == [1, 2]
         Device::UNIVERSAL
-      elsif !info.try(:[], 'DTSDKName').nil? || !info.try(:[], 'DTPlatformName').nil?
+      elsif !info.try(:[], 'DTSDKName').nil? || !info.try(:[], 'DTManufacturerName').nil?
         Device::MACOS
       else
         raise NotImplementedError, "Unkonwn device: #{device_family}"

--- a/lib/app_info/mobile_provision.rb
+++ b/lib/app_info/mobile_provision.rb
@@ -7,20 +7,20 @@ module AppInfo
   # Apple code signing: provisioning profile parser
   # @see https://developer.apple.com/documentation/technotes/tn3125-inside-code-signing-provisioning-profiles
   class MobileProvision < File
-    # @return [Symbol] {Platform}
-    def platform
-      Platform::APPLE
+    # @return [Symbol] {Manufacturer}
+    def manufacturer
+      Manufacturer::APPLE
     end
 
-    # @return [Symbol] {OperaSystem}
-    def opera_system
-      case opera_systems[0]
+    # @return [Symbol] {Platform}
+    def platform
+      case platforms[0]
       when :macos
-        OperaSystem::MACOS
+        Platform::MACOS
       when :ios
-        OperaSystem::IOS
+        Platform::IOS
       else
-        raise NotImplementedError, "Unkonwn opera_system: #{opera_systems[0]}"
+        raise NotImplementedError, "Unkonwn platform: #{platforms[0]}"
       end
     end
 
@@ -43,7 +43,7 @@ module AppInfo
     end
 
     # @return [Array<Symbol>]
-    def opera_systems
+    def platforms
       return unless platforms = mobileprovision.try(:[], 'Platform')
 
       platforms.map do |v|
@@ -111,13 +111,13 @@ module AppInfo
     # @see https://stackoverflow.com/questions/1003066/what-does-get-task-allow-do-in-xcode
     # @return [Boolea]
     def development?
-      case opera_system
-      when OperaSystem::IOS
+      case platform
+      when Platform::IOS
         entitlements['get-task-allow'] == true
-      when OperaSystem::MACOS
+      when Platform::MACOS
         !devices.nil?
       else
-        raise NotImplementedError, "Unknown opera_system: #{opera_system}"
+        raise NotImplementedError, "Unknown platform: #{platform}"
       end
     end
 
@@ -126,26 +126,26 @@ module AppInfo
     # @see https://developer.apple.com/library/archive/qa/qa1830/_index.html
     # @return [Boolea]
     def appstore?
-      case opera_system
-      when OperaSystem::IOS
+      case platform
+      when Platform::IOS
         !development? && entitlements.key?('beta-reports-active')
-      when OperaSystem::MACOS
+      when Platform::MACOS
         !development?
       else
-        raise NotImplementedError, "Unknown opera_system: #{opera_system}"
+        raise NotImplementedError, "Unknown platform: #{platform}"
       end
     end
 
     # @return [Boolea]
     def adhoc?
-      return false if opera_system == OperaSystem::MACOS # macOS no need adhoc
+      return false if platform == Platform::MACOS # macOS no need adhoc
 
       !development? && !devices.nil?
     end
 
     # @return [Boolea]
     def enterprise?
-      return false if opera_system == OperaSystem::MACOS # macOS no need adhoc
+      return false if platform == Platform::MACOS # macOS no need adhoc
 
       !development? && !adhoc? && !appstore?
     end

--- a/lib/app_info/pe.rb
+++ b/lib/app_info/pe.rb
@@ -68,11 +68,48 @@ module AppInfo
     # @!method assembly_version
     #   @see VersionInfo#assembly_version
     #   @return [String]
-    def_delegators :version_info, :product_name, :product_version, :company_name, :assembly_version
+    # @!method file_version
+    #   @see VersionInfo#file_version
+    #   @return [String]
+    # @!method file_description
+    #   @see VersionInfo#file_description
+    #   @return [String]
+    # @!method copyright
+    #   @see VersionInfo#copyright
+    #   @return [String]
+    #   @return [String]
+    # @!method special_build
+    #   @see VersionInfo#special_build
+    #   @return [String]
+    # @!method private_build
+    #   @see VersionInfo#private_build
+    #   @return [String]
+    # @!method original_filename
+    #   @see VersionInfo#original_filename
+    #   @return [String]
+    # @!method internal_name
+    #   @see VersionInfo#internal_name
+    #   @return [String]
+    # @!method legal_trademarks
+    #   @see VersionInfo#legal_trademarks
+    #   @return [String]
+    def_delegators :version_info, :product_name, :product_version, :company_name, :assembly_version,
+                   :file_version, :file_description, :copyright, :special_build, :private_build,
+                   :original_filename, :internal_name, :legal_trademarks
 
     alias name product_name
-    alias release_version product_version
-    alias build_version assembly_version
+
+    # Find {#product_version} then fallback to {#file_version}
+    # @return [String, nil]
+    def release_version
+      product_version || file_version
+    end
+
+    # Find {#special_build}, {#private_build} then fallback to {#assembly_version}
+    # @return [String, nil]
+    def build_version
+      special_build || private_build || assembly_version
+    end
 
     # @return [String]
     def archs
@@ -189,7 +226,7 @@ module AppInfo
 
     # VersionInfo class
     #
-    # Ref: https://learn.microsoft.com/zh-cn/windows/win32/menurc/versioninfo-resource
+    # @see https://learn.microsoft.com/zh-cn/windows/win32/menurc/versioninfo-resource
     class VersionInfo
       def initialize(raw)
         @raw = raw
@@ -220,9 +257,34 @@ module AppInfo
         @file_version ||= value_of('FileVersion')
       end
 
-      # @return [String]
+      # @return [String, nil]
       def file_description
         @file_description ||= value_of('FileDescription')
+      end
+
+      # @return [String, nil]
+      def special_build
+        @special_build ||= value_of('SpecialBuild')
+      end
+
+      # @return [String, nil]
+      def private_build
+        @private_build ||= value_of('PrivateBuild')
+      end
+
+      # @return [String]
+      def original_filename
+        @original_filename ||= value_of('OriginalFilename')
+      end
+
+      # @return [String]
+      def internal_name
+        @internal_name ||= value_of('InternalName')
+      end
+
+      # @return [String]
+      def legal_trademarks
+        @legal_trademarks ||= value_of('LegalTrademarks')
       end
 
       # @return [String]

--- a/lib/app_info/pe.rb
+++ b/lib/app_info/pe.rb
@@ -24,14 +24,14 @@ module AppInfo
       0x5128 => 'RISC-v 128'
     }.freeze
 
+    # @return [Symbol] {Manufacturer}
+    def manufacturer
+      Manufacturer::MICROSOFT
+    end
+
     # @return [Symbol] {Platform}
     def platform
       Platform::WINDOWS
-    end
-
-    # @return [Symbol] {OperaSystem}
-    def opera_system
-      OperaSystem::WINDOWS
     end
 
     # @return [Symbol] {Device}

--- a/lib/app_info/proguard.rb
+++ b/lib/app_info/proguard.rb
@@ -10,14 +10,14 @@ module AppInfo
 
     NAMESPACE = UUIDTools::UUID.sha1_create(UUIDTools::UUID_DNS_NAMESPACE, 'icyleaf.com')
 
-    # @return [Symbol] {Platform}
-    def platform
-      Platform::GOOGLE
+    # @return [Symbol] {Manufacturer}
+    def manufacturer
+      Manufacturer::GOOGLE
     end
 
-    # @return [Symbol] {OperaSystem}
-    def opera_system
-      OperaSystem::ANDROID
+    # @return [Symbol] {Platform}
+    def platform
+      Platform::ANDROID
     end
 
     # @return [String]

--- a/lib/app_info/version.rb
+++ b/lib/app_info/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module AppInfo
-  VERSION = '3.0.0.beta2'
+  VERSION = '3.0.0.beta3'
 end

--- a/spec/app_info/aab_spec.rb
+++ b/spec/app_info/aab_spec.rb
@@ -11,10 +11,10 @@ describe AppInfo::APK do
       it { expect(subject.size(human_size: true)).to eq('3.45 MB') }
       it { expect(subject.format).to eq(AppInfo::Format::AAB) }
       it { expect(subject.format).to eq(:aab) }
-      it { expect(subject.platform).to eq(AppInfo::Platform::GOOGLE) }
-      it { expect(subject.platform).to eq(:google) }
-      it { expect(subject.opera_system).to eq(AppInfo::OperaSystem::ANDROID) }
-      it { expect(subject.opera_system).to eq(:android) }
+      it { expect(subject.manufacturer).to eq(AppInfo::Manufacturer::GOOGLE) }
+      it { expect(subject.manufacturer).to eq(:google) }
+      it { expect(subject.platform).to eq(AppInfo::Platform::ANDROID) }
+      it { expect(subject.platform).to eq(:android) }
       it { expect(subject.device).to eq(AppInfo::Device::PHONE) }
       it { expect(subject.device).to eq(:phone) }
       it { expect(subject).not_to be_tablet }
@@ -55,10 +55,10 @@ describe AppInfo::APK do
       it { expect(subject.size(human_size: true)).to eq('7.10 MB') }
       it { expect(subject.format).to eq(AppInfo::Format::AAB) }
       it { expect(subject.format).to eq(:aab) }
-      it { expect(subject.platform).to eq(AppInfo::Platform::GOOGLE) }
-      it { expect(subject.platform).to eq(:google) }
-      it { expect(subject.opera_system).to eq(AppInfo::OperaSystem::ANDROID) }
-      it { expect(subject.opera_system).to eq(:android) }
+      it { expect(subject.manufacturer).to eq(AppInfo::Manufacturer::GOOGLE) }
+      it { expect(subject.manufacturer).to eq(:google) }
+      it { expect(subject.platform).to eq(AppInfo::Platform::ANDROID) }
+      it { expect(subject.platform).to eq(:android) }
       it { expect(subject.device).to eq(AppInfo::Device::PHONE) }
       it { expect(subject.device).to eq(:phone) }
       it { expect(subject).not_to be_tablet }

--- a/spec/app_info/android_spec.rb
+++ b/spec/app_info/android_spec.rb
@@ -6,10 +6,10 @@ describe AppInfo::Android do
     it { expect(subject.file).to eq file }
     it { expect(subject.size).to eq(3618865) }
     it { expect(subject.size(human_size: true)).to eq('3.45 MB') }
-    it { expect(subject.platform).to eq(AppInfo::Platform::GOOGLE) }
-    it { expect(subject.platform).to eq(:google) }
-    it { expect(subject.opera_system).to eq(AppInfo::OperaSystem::ANDROID) }
-    it { expect(subject.opera_system).to eq(:android) }
+    it { expect(subject.manufacturer).to eq(AppInfo::Manufacturer::GOOGLE) }
+    it { expect(subject.manufacturer).to eq(:google) }
+    it { expect(subject.platform).to eq(AppInfo::Platform::ANDROID) }
+    it { expect(subject.platform).to eq(:android) }
     it { expect { subject.format }.to raise_error NotImplementedError }
     it { expect { subject.name }.to raise_error NotImplementedError }
     it { expect { subject.use_features }.to raise_error NotImplementedError }
@@ -31,10 +31,10 @@ describe AppInfo::Android do
     it { expect(subject.file).to eq file }
     it { expect(subject.size).to eq(4000563) }
     it { expect(subject.size(human_size: true)).to eq('3.82 MB') }
-    it { expect(subject.platform).to eq(AppInfo::Platform::GOOGLE) }
-    it { expect(subject.platform).to eq(:google) }
-    it { expect(subject.opera_system).to eq(AppInfo::OperaSystem::ANDROID) }
-    it { expect(subject.opera_system).to eq(:android) }
+    it { expect(subject.manufacturer).to eq(AppInfo::Manufacturer::GOOGLE) }
+    it { expect(subject.manufacturer).to eq(:google) }
+    it { expect(subject.platform).to eq(AppInfo::Platform::ANDROID) }
+    it { expect(subject.platform).to eq(:android) }
     it { expect { subject.format }.to raise_error NotImplementedError }
     it { expect { subject.name }.to raise_error NotImplementedError }
     it { expect { subject.use_features }.to raise_error NotImplementedError }

--- a/spec/app_info/apk_spec.rb
+++ b/spec/app_info/apk_spec.rb
@@ -12,18 +12,18 @@ describe AppInfo::APK do
       it { expect(subject.size(human_size: true)).to eq('3.82 MB') }
       # it { expect(subject.file_type).to eq :apk }
       # it { expect(subject.file_type).to eq AppInfo::Format::APK }
-      # it { expect(subject.platform).to eq 'Android' }
-      # it { expect(subject.platform).to eq AppInfo::Platform::ANDROID }
+      # it { expect(subject.manufacturer).to eq 'Android' }
+      # it { expect(subject.manufacturer).to eq AppInfo::Manufacturer::ANDROID }
       # it { expect(subject.wear?).to be false }
       # it { expect(subject.tv?).to be false }
       # it { expect(subject.automotive?).to be false }
       # it { expect(subject.device_type).to eq AppInfo::APK::Device::PHONE }
       it { expect(subject.format).to eq(AppInfo::Format::APK) }
       it { expect(subject.format).to eq(:apk) }
-      it { expect(subject.platform).to eq(AppInfo::Platform::GOOGLE) }
-      it { expect(subject.platform).to eq(:google) }
-      it { expect(subject.opera_system).to eq(AppInfo::OperaSystem::ANDROID) }
-      it { expect(subject.opera_system).to eq(:android) }
+      it { expect(subject.manufacturer).to eq(AppInfo::Manufacturer::GOOGLE) }
+      it { expect(subject.manufacturer).to eq(:google) }
+      it { expect(subject.platform).to eq(AppInfo::Platform::ANDROID) }
+      it { expect(subject.platform).to eq(:android) }
       it { expect(subject.device).to eq(AppInfo::Device::PHONE) }
       it { expect(subject.device).to eq(:phone) }
       it { expect(subject).not_to be_tablet }
@@ -68,10 +68,10 @@ describe AppInfo::APK do
     it { expect(subject.apk).to be_a Android::Apk }
     it { expect(subject.format).to eq(AppInfo::Format::APK) }
     it { expect(subject.format).to eq(:apk) }
-    it { expect(subject.platform).to eq(AppInfo::Platform::GOOGLE) }
-    it { expect(subject.platform).to eq(:google) }
-    it { expect(subject.opera_system).to eq(AppInfo::OperaSystem::ANDROID) }
-    it { expect(subject.opera_system).to eq(:android) }
+    it { expect(subject.manufacturer).to eq(AppInfo::Manufacturer::GOOGLE) }
+    it { expect(subject.manufacturer).to eq(:google) }
+    it { expect(subject.platform).to eq(AppInfo::Platform::ANDROID) }
+    it { expect(subject.platform).to eq(:android) }
     it { expect(subject.device).to eq(AppInfo::Device::WATCH) }
     it { expect(subject.device).to eq(:watch) }
     it { expect(subject).not_to be_tablet }
@@ -98,10 +98,10 @@ describe AppInfo::APK do
     it { expect(subject.apk).to be_a Android::Apk }
     it { expect(subject.format).to eq(AppInfo::Format::APK) }
     it { expect(subject.format).to eq(:apk) }
-    it { expect(subject.platform).to eq(AppInfo::Platform::GOOGLE) }
-    it { expect(subject.platform).to eq(:google) }
-    it { expect(subject.opera_system).to eq(AppInfo::OperaSystem::ANDROID) }
-    it { expect(subject.opera_system).to eq(:android) }
+    it { expect(subject.manufacturer).to eq(AppInfo::Manufacturer::GOOGLE) }
+    it { expect(subject.manufacturer).to eq(:google) }
+    it { expect(subject.platform).to eq(AppInfo::Platform::ANDROID) }
+    it { expect(subject.platform).to eq(:android) }
     it { expect(subject.device).to eq(AppInfo::Device::TELEVISION) }
     it { expect(subject.device).to eq(:television) }
     it { expect(subject).not_to be_tablet }
@@ -128,10 +128,10 @@ describe AppInfo::APK do
     it { expect(subject.apk).to be_a Android::Apk }
     it { expect(subject.format).to eq(AppInfo::Format::APK) }
     it { expect(subject.format).to eq(:apk) }
-    it { expect(subject.platform).to eq(AppInfo::Platform::GOOGLE) }
-    it { expect(subject.platform).to eq(:google) }
-    it { expect(subject.opera_system).to eq(AppInfo::OperaSystem::ANDROID) }
-    it { expect(subject.opera_system).to eq(:android) }
+    it { expect(subject.manufacturer).to eq(AppInfo::Manufacturer::GOOGLE) }
+    it { expect(subject.manufacturer).to eq(:google) }
+    it { expect(subject.platform).to eq(AppInfo::Platform::ANDROID) }
+    it { expect(subject.platform).to eq(:android) }
     it { expect(subject.device).to eq(AppInfo::Device::AUTOMOTIVE) }
     it { expect(subject.device).to eq(:automotive) }
     it { expect(subject).not_to be_tablet }

--- a/spec/app_info/apple_spec.rb
+++ b/spec/app_info/apple_spec.rb
@@ -4,10 +4,10 @@ describe AppInfo::Apple do
     subject { AppInfo::Apple.new(file) }
 
     it { expect(subject.file).to eq file }
-    it { expect(subject.platform).to eq(AppInfo::Platform::APPLE) }
-    it { expect(subject.platform).to eq(:apple) }
+    it { expect(subject.manufacturer).to eq(AppInfo::Manufacturer::APPLE) }
+    it { expect(subject.manufacturer).to eq(:apple) }
     it { expect { subject.format }.to raise_error NotImplementedError }
-    it { expect { subject.opera_system }.to raise_error NotImplementedError }
+    it { expect { subject.platform }.to raise_error NotImplementedError }
     it { expect { subject.distribution_name }.to raise_error NotImplementedError }
     it { expect { subject.info }.to raise_error NotImplementedError }
     it { expect { subject.icons }.to raise_error NotImplementedError }
@@ -24,10 +24,10 @@ describe AppInfo::Apple do
     subject { AppInfo::Apple.new(file) }
 
     it { expect(subject.file).to eq file }
-    it { expect(subject.platform).to eq(AppInfo::Platform::APPLE) }
-    it { expect(subject.platform).to eq(:apple) }
+    it { expect(subject.manufacturer).to eq(AppInfo::Manufacturer::APPLE) }
+    it { expect(subject.manufacturer).to eq(:apple) }
     it { expect { subject.format }.to raise_error NotImplementedError }
-    it { expect { subject.opera_system }.to raise_error NotImplementedError }
+    it { expect { subject.platform }.to raise_error NotImplementedError }
     it { expect { subject.distribution_name }.to raise_error NotImplementedError }
     it { expect { subject.info }.to raise_error NotImplementedError }
     it { expect { subject.icons }.to raise_error NotImplementedError }

--- a/spec/app_info/const_spec.rb
+++ b/spec/app_info/const_spec.rb
@@ -1,14 +1,14 @@
-describe AppInfo::Platform do
-  it { expect(AppInfo::Platform::APPLE).to eq :apple }
-  it { expect(AppInfo::Platform::GOOGLE).to eq :google }
-  it { expect(AppInfo::Platform::WINDOWS).to eq :windows }
+describe AppInfo::Manufacturer do
+  it { expect(AppInfo::Manufacturer::APPLE).to eq :apple }
+  it { expect(AppInfo::Manufacturer::GOOGLE).to eq :google }
+  it { expect(AppInfo::Manufacturer::MICROSOFT).to eq :microsoft }
 end
 
-describe AppInfo::OperaSystem do
-  it { expect(AppInfo::OperaSystem::MACOS).to eq :macos }
-  it { expect(AppInfo::OperaSystem::IOS).to eq :ios }
-  it { expect(AppInfo::OperaSystem::ANDROID).to eq :android }
-  it { expect(AppInfo::OperaSystem::WINDOWS).to eq :windows }
+describe AppInfo::Platform do
+  it { expect(AppInfo::Platform::MACOS).to eq :macos }
+  it { expect(AppInfo::Platform::IOS).to eq :ios }
+  it { expect(AppInfo::Platform::ANDROID).to eq :android }
+  it { expect(AppInfo::Platform::WINDOWS).to eq :windows }
 end
 
 describe AppInfo::Device do

--- a/spec/app_info/dsym_spec.rb
+++ b/spec/app_info/dsym_spec.rb
@@ -17,9 +17,9 @@ describe AppInfo::DSYM do
         it { expect(subject.file).to eq fixture_path('dsyms/iOS-single-dSYM-with-single-macho.zip') }
         it { expect(subject.format).to eq AppInfo::Format::DSYM }
         it { expect(subject.format).to eq :dsym }
-        it { expect(subject.platform).to eq(AppInfo::Platform::APPLE) }
-        it { expect(subject.platform).to eq(:apple) }
-        it { expect{ subject.opera_system }.to raise_error NotImplementedError }
+        it { expect(subject.manufacturer).to eq(AppInfo::Manufacturer::APPLE) }
+        it { expect(subject.manufacturer).to eq(:apple) }
+        it { expect{ subject.platform }.to raise_error NotImplementedError }
         it { expect{ subject.device }.to raise_error NotImplementedError }
         it { expect(subject.files.size).to eq 1 }
         it { expect(subject.files[0].object).to eq 'iOS' }
@@ -67,9 +67,9 @@ describe AppInfo::DSYM do
         it { expect(subject.file).to eq fixture_path('dsyms/iOS-single-dSYM-with-multi-macho.zip') }
         it { expect(subject.format).to eq AppInfo::Format::DSYM }
         it { expect(subject.format).to eq :dsym }
-        it { expect(subject.platform).to eq(AppInfo::Platform::APPLE) }
-        it { expect(subject.platform).to eq(:apple) }
-        it { expect{ subject.opera_system }.to raise_error NotImplementedError }
+        it { expect(subject.manufacturer).to eq(AppInfo::Manufacturer::APPLE) }
+        it { expect(subject.manufacturer).to eq(:apple) }
+        it { expect{ subject.platform }.to raise_error NotImplementedError }
         it { expect{ subject.device }.to raise_error NotImplementedError }
         it { expect(subject.files.size).to eq 1 }
         it { expect(subject.files[0].object).to eq 'iOS' }
@@ -128,9 +128,9 @@ describe AppInfo::DSYM do
         it { expect(subject.file).to eq file }
         it { expect(subject.format).to eq AppInfo::Format::DSYM }
         it { expect(subject.format).to eq :dsym }
-        it { expect(subject.platform).to eq(AppInfo::Platform::APPLE) }
-        it { expect(subject.platform).to eq(:apple) }
-        it { expect{ subject.opera_system }.to raise_error NotImplementedError }
+        it { expect(subject.manufacturer).to eq(AppInfo::Manufacturer::APPLE) }
+        it { expect(subject.manufacturer).to eq(:apple) }
+        it { expect{ subject.platform }.to raise_error NotImplementedError }
         it { expect{ subject.device }.to raise_error NotImplementedError }
         it { expect(subject.files.size).to eq 2 }
         it { expect(subject.files[0].object).to eq 'AppInfo' }
@@ -195,9 +195,9 @@ describe AppInfo::DSYM do
         it { expect(subject.file).to eq file }
         it { expect(subject.format).to eq AppInfo::Format::DSYM }
         it { expect(subject.format).to eq :dsym }
-        it { expect(subject.platform).to eq(AppInfo::Platform::APPLE) }
-        it { expect(subject.platform).to eq(:apple) }
-        it { expect{ subject.opera_system }.to raise_error NotImplementedError }
+        it { expect(subject.manufacturer).to eq(AppInfo::Manufacturer::APPLE) }
+        it { expect(subject.manufacturer).to eq(:apple) }
+        it { expect{ subject.platform }.to raise_error NotImplementedError }
         it { expect{ subject.device }.to raise_error NotImplementedError }
         it { expect(subject.files.size).to eq 2 }
         it { expect(subject.files[0].object).to eq 'AppInfo' }

--- a/spec/app_info/file_spec.rb
+++ b/spec/app_info/file_spec.rb
@@ -5,8 +5,8 @@ describe AppInfo::File do
 
     context 'parse' do
       it { expect{ subject.format }.to raise_error NotImplementedError }
+      it { expect{ subject.manufacturer }.to raise_error NotImplementedError }
       it { expect{ subject.platform }.to raise_error NotImplementedError }
-      it { expect{ subject.opera_system }.to raise_error NotImplementedError }
       it { expect{ subject.device }.to raise_error NotImplementedError }
       it { expect{ subject.size }.to raise_error NotImplementedError }
     end

--- a/spec/app_info/info_plist_spec.rb
+++ b/spec/app_info/info_plist_spec.rb
@@ -5,10 +5,10 @@ describe AppInfo::InfoPlist do
 
     it { expect(subject.format).to eq AppInfo::Format::INFOPLIST }
     it { expect(subject.format).to eq :infoplist }
-    it { expect(subject.platform).to eq(AppInfo::Platform::APPLE) }
-    it { expect(subject.platform).to eq(:apple) }
-    it { expect(subject.opera_system).to eq(AppInfo::OperaSystem::IOS) }
-    it { expect(subject.opera_system).to eq(:ios) }
+    it { expect(subject.manufacturer).to eq(AppInfo::Manufacturer::APPLE) }
+    it { expect(subject.manufacturer).to eq(:apple) }
+    it { expect(subject.platform).to eq(AppInfo::Platform::IOS) }
+    it { expect(subject.platform).to eq(:ios) }
     it { expect(subject.device).to eq(AppInfo::Device::IPHONE) }
     it { expect(subject.device).to eq(:iphone) }
     it { expect(subject).to be_iphone }
@@ -39,10 +39,10 @@ describe AppInfo::InfoPlist do
 
     it { expect(subject.format).to eq AppInfo::Format::INFOPLIST }
     it { expect(subject.format).to eq :infoplist }
-    it { expect(subject.platform).to eq(AppInfo::Platform::APPLE) }
-    it { expect(subject.platform).to eq(:apple) }
-    it { expect(subject.opera_system).to eq(AppInfo::OperaSystem::IOS) }
-    it { expect(subject.opera_system).to eq(:ios) }
+    it { expect(subject.manufacturer).to eq(AppInfo::Manufacturer::APPLE) }
+    it { expect(subject.manufacturer).to eq(:apple) }
+    it { expect(subject.platform).to eq(AppInfo::Platform::IOS) }
+    it { expect(subject.platform).to eq(:ios) }
     it { expect(subject.device).to eq(AppInfo::Device::IPAD) }
     it { expect(subject.device).to eq(:ipad) }
     it { expect(subject).not_to be_iphone }
@@ -73,10 +73,10 @@ describe AppInfo::InfoPlist do
 
     it { expect(subject.format).to eq AppInfo::Format::INFOPLIST }
     it { expect(subject.format).to eq :infoplist }
-    it { expect(subject.platform).to eq(AppInfo::Platform::APPLE) }
-    it { expect(subject.platform).to eq(:apple) }
-    it { expect(subject.opera_system).to eq(AppInfo::OperaSystem::IOS) }
-    it { expect(subject.opera_system).to eq(:ios) }
+    it { expect(subject.manufacturer).to eq(AppInfo::Manufacturer::APPLE) }
+    it { expect(subject.manufacturer).to eq(:apple) }
+    it { expect(subject.platform).to eq(AppInfo::Platform::IOS) }
+    it { expect(subject.platform).to eq(:ios) }
     it { expect(subject.device).to eq(AppInfo::Device::UNIVERSAL) }
     it { expect(subject.device).to eq(:universal) }
     it { expect(subject).not_to be_iphone }
@@ -107,10 +107,10 @@ describe AppInfo::InfoPlist do
 
     it { expect(subject.format).to eq AppInfo::Format::INFOPLIST }
     it { expect(subject.format).to eq :infoplist }
-    it { expect(subject.platform).to eq(AppInfo::Platform::APPLE) }
-    it { expect(subject.platform).to eq(:apple) }
-    it { expect(subject.opera_system).to eq(AppInfo::OperaSystem::MACOS) }
-    it { expect(subject.opera_system).to eq(:macos) }
+    it { expect(subject.manufacturer).to eq(AppInfo::Manufacturer::APPLE) }
+    it { expect(subject.manufacturer).to eq(:apple) }
+    it { expect(subject.platform).to eq(AppInfo::Platform::MACOS) }
+    it { expect(subject.platform).to eq(:macos) }
     it { expect(subject.device).to eq(AppInfo::Device::MACOS) }
     it { expect(subject.device).to eq(:macos) }
     it { expect(subject).not_to be_iphone }

--- a/spec/app_info/ipa_spec.rb
+++ b/spec/app_info/ipa_spec.rb
@@ -8,10 +8,10 @@ describe AppInfo::IPA do
     it { expect(subject.file).to eq file }
     it { expect(subject.format).to eq AppInfo::Format::IPA }
     it { expect(subject.format).to eq :ipa }
-    it { expect(subject.platform).to eq(AppInfo::Platform::APPLE) }
-    it { expect(subject.platform).to eq(:apple) }
-    it { expect(subject.opera_system).to eq(AppInfo::OperaSystem::IOS) }
-    it { expect(subject.opera_system).to eq(:ios) }
+    it { expect(subject.manufacturer).to eq(AppInfo::Manufacturer::APPLE) }
+    it { expect(subject.manufacturer).to eq(:apple) }
+    it { expect(subject.platform).to eq(AppInfo::Platform::IOS) }
+    it { expect(subject.platform).to eq(:ios) }
     it { expect(subject.device).to eq(AppInfo::Device::IPHONE) }
     it { expect(subject.device).to eq(:iphone) }
     it { expect(subject).to be_iphone }
@@ -61,10 +61,10 @@ describe AppInfo::IPA do
     it { expect(subject.file).to eq file }
     it { expect(subject.format).to eq AppInfo::Format::IPA }
     it { expect(subject.format).to eq :ipa }
-    it { expect(subject.platform).to eq(AppInfo::Platform::APPLE) }
-    it { expect(subject.platform).to eq(:apple) }
-    it { expect(subject.opera_system).to eq(AppInfo::OperaSystem::IOS) }
-    it { expect(subject.opera_system).to eq(:ios) }
+    it { expect(subject.manufacturer).to eq(AppInfo::Manufacturer::APPLE) }
+    it { expect(subject.manufacturer).to eq(:apple) }
+    it { expect(subject.platform).to eq(AppInfo::Platform::IOS) }
+    it { expect(subject.platform).to eq(:ios) }
     it { expect(subject.device).to eq(AppInfo::Device::IPAD) }
     it { expect(subject.device).to eq(:ipad) }
     it { expect(subject).not_to be_iphone }
@@ -121,10 +121,10 @@ describe AppInfo::IPA do
     it { expect(subject.file).to eq file }
     it { expect(subject.format).to eq AppInfo::Format::IPA }
     it { expect(subject.format).to eq :ipa }
-    it { expect(subject.platform).to eq(AppInfo::Platform::APPLE) }
-    it { expect(subject.platform).to eq(:apple) }
-    it { expect(subject.opera_system).to eq(AppInfo::OperaSystem::IOS) }
-    it { expect(subject.opera_system).to eq(:ios) }
+    it { expect(subject.manufacturer).to eq(AppInfo::Manufacturer::APPLE) }
+    it { expect(subject.manufacturer).to eq(:apple) }
+    it { expect(subject.platform).to eq(AppInfo::Platform::IOS) }
+    it { expect(subject.platform).to eq(:ios) }
     it { expect(subject.device).to eq(AppInfo::Device::UNIVERSAL) }
     it { expect(subject.device).to eq(:universal) }
     it { expect(subject).not_to be_iphone }

--- a/spec/app_info/macos_spec.rb
+++ b/spec/app_info/macos_spec.rb
@@ -10,10 +10,10 @@ describe AppInfo::Macos do
         it { expect(subject.file).to eq file }
         it { expect(subject.format).to eq AppInfo::Format::MACOS }
         it { expect(subject.format).to eq :macos }
-        it { expect(subject.platform).to eq(AppInfo::Platform::APPLE) }
-        it { expect(subject.platform).to eq(:apple) }
-        it { expect(subject.opera_system).to eq(AppInfo::OperaSystem::MACOS) }
-        it { expect(subject.opera_system).to eq(:macos) }
+        it { expect(subject.manufacturer).to eq(AppInfo::Manufacturer::APPLE) }
+        it { expect(subject.manufacturer).to eq(:apple) }
+        it { expect(subject.platform).to eq(AppInfo::Platform::MACOS) }
+        it { expect(subject.platform).to eq(:macos) }
         it { expect(subject.device).to eq(AppInfo::Device::MACOS) }
         it { expect(subject.device).to eq(:macos) }
         it { expect(subject.build_version).to eq('1') }
@@ -54,10 +54,10 @@ describe AppInfo::Macos do
         it { expect(subject.file).to eq file }
         it { expect(subject.format).to eq AppInfo::Format::MACOS }
         it { expect(subject.format).to eq :macos }
-        it { expect(subject.platform).to eq(AppInfo::Platform::APPLE) }
-        it { expect(subject.platform).to eq(:apple) }
-        it { expect(subject.opera_system).to eq(AppInfo::OperaSystem::MACOS) }
-        it { expect(subject.opera_system).to eq(:macos) }
+        it { expect(subject.manufacturer).to eq(AppInfo::Manufacturer::APPLE) }
+        it { expect(subject.manufacturer).to eq(:apple) }
+        it { expect(subject.platform).to eq(AppInfo::Platform::MACOS) }
+        it { expect(subject.platform).to eq(:macos) }
         it { expect(subject.device).to eq(AppInfo::Device::MACOS) }
         it { expect(subject.device).to eq(:macos) }
         it { expect(subject.build_version).to eq('1') }

--- a/spec/app_info/mobile_provision_spec.rb
+++ b/spec/app_info/mobile_provision_spec.rb
@@ -5,11 +5,11 @@ describe AppInfo::MobileProvision do
 
       it { expect(subject.format).to eq AppInfo::Format::MOBILEPROVISION }
       it { expect(subject.format).to eq :mobileprovision }
-      it { expect(subject.platform).to eq AppInfo::Platform::APPLE }
-      it { expect(subject.platform).to eq :apple }
-      it { expect(subject.opera_system).to eq AppInfo::OperaSystem::IOS }
-      it { expect(subject.opera_system).to eq :ios }
-      it { expect(subject.opera_systems).to eq [:ios] }
+      it { expect(subject.manufacturer).to eq AppInfo::Manufacturer::APPLE }
+      it { expect(subject.manufacturer).to eq :apple }
+      it { expect(subject.platform).to eq AppInfo::Platform::IOS }
+      it { expect(subject.platform).to eq :ios }
+      it { expect(subject.platforms).to eq [:ios] }
       it { expect{ subject.device }.to raise_error NotImplementedError }
       it { expect(subject.devices).to eq(['e801228c2086d3aacc917b9c3d19bfa56efcab5b']) }
       it { expect(subject.name).to_not be_empty }
@@ -38,13 +38,13 @@ describe AppInfo::MobileProvision do
 
       it { expect(subject.format).to eq AppInfo::Format::MOBILEPROVISION }
       it { expect(subject.format).to eq :mobileprovision }
-      it { expect(subject.platform).to eq AppInfo::Platform::APPLE }
-      it { expect(subject.platform).to eq :apple }
-      it { expect(subject.opera_system).to eq AppInfo::OperaSystem::IOS }
-      it { expect(subject.opera_system).to eq :ios }
-      it { expect(subject.opera_system).to eq AppInfo::OperaSystem::IOS }
-      it { expect(subject.opera_system).to eq :ios }
-      it { expect(subject.opera_systems).to eq [:ios] }
+      it { expect(subject.manufacturer).to eq AppInfo::Manufacturer::APPLE }
+      it { expect(subject.manufacturer).to eq :apple }
+      it { expect(subject.platform).to eq AppInfo::Platform::IOS }
+      it { expect(subject.platform).to eq :ios }
+      it { expect(subject.platform).to eq AppInfo::Platform::IOS }
+      it { expect(subject.platform).to eq :ios }
+      it { expect(subject.platforms).to eq [:ios] }
       it { expect{ subject.device }.to raise_error NotImplementedError }
       it { expect(subject.devices).to be_a Array }
       it { expect(subject.devices).to eq(['e801228c2086d3aacc917b9c3d19bfa56efcab5b']) }
@@ -71,11 +71,11 @@ describe AppInfo::MobileProvision do
 
       it { expect(subject.format).to eq AppInfo::Format::MOBILEPROVISION }
       it { expect(subject.format).to eq :mobileprovision }
-      it { expect(subject.platform).to eq AppInfo::Platform::APPLE }
-      it { expect(subject.platform).to eq :apple }
-      it { expect(subject.opera_system).to eq AppInfo::OperaSystem::IOS }
-      it { expect(subject.opera_system).to eq :ios }
-      it { expect(subject.opera_systems).to eq [:ios] }
+      it { expect(subject.manufacturer).to eq AppInfo::Manufacturer::APPLE }
+      it { expect(subject.manufacturer).to eq :apple }
+      it { expect(subject.platform).to eq AppInfo::Platform::IOS }
+      it { expect(subject.platform).to eq :ios }
+      it { expect(subject.platforms).to eq [:ios] }
       it { expect{ subject.device }.to raise_error NotImplementedError }
       it { expect(subject.devices).to be_nil }
       it { expect(subject.name).to_not be_empty }
@@ -103,11 +103,11 @@ describe AppInfo::MobileProvision do
 
       it { expect(subject.format).to eq AppInfo::Format::MOBILEPROVISION }
       it { expect(subject.format).to eq :mobileprovision }
-      it { expect(subject.platform).to eq AppInfo::Platform::APPLE }
-      it { expect(subject.platform).to eq :apple }
-      it { expect(subject.opera_system).to eq AppInfo::OperaSystem::MACOS }
-      it { expect(subject.opera_system).to eq :macos }
-      it { expect(subject.opera_systems).to eq [:macos] }
+      it { expect(subject.manufacturer).to eq AppInfo::Manufacturer::APPLE }
+      it { expect(subject.manufacturer).to eq :apple }
+      it { expect(subject.platform).to eq AppInfo::Platform::MACOS }
+      it { expect(subject.platform).to eq :macos }
+      it { expect(subject.platforms).to eq [:macos] }
       it { expect{ subject.device }.to raise_error NotImplementedError }
       it { expect(subject.devices).to be_a Array }
       it { expect(subject.name).to_not be_empty }
@@ -133,11 +133,11 @@ describe AppInfo::MobileProvision do
 
       it { expect(subject.format).to eq AppInfo::Format::MOBILEPROVISION }
       it { expect(subject.format).to eq :mobileprovision }
-      it { expect(subject.platform).to eq AppInfo::Platform::APPLE }
-      it { expect(subject.platform).to eq :apple }
-      it { expect(subject.opera_system).to eq AppInfo::OperaSystem::MACOS }
-      it { expect(subject.opera_system).to eq :macos }
-      it { expect(subject.opera_systems).to eq [:macos] }
+      it { expect(subject.manufacturer).to eq AppInfo::Manufacturer::APPLE }
+      it { expect(subject.manufacturer).to eq :apple }
+      it { expect(subject.platform).to eq AppInfo::Platform::MACOS }
+      it { expect(subject.platform).to eq :macos }
+      it { expect(subject.platforms).to eq [:macos] }
       it { expect{ subject.device }.to raise_error NotImplementedError }
       it { expect(subject.devices).to be_nil }
       it { expect(subject.name).to_not be_empty }

--- a/spec/app_info/pe_spec.rb
+++ b/spec/app_info/pe_spec.rb
@@ -9,10 +9,10 @@ describe AppInfo::PE do
       it { expect(subject.file).to eq file }
       it { expect(subject.format).to eq AppInfo::Format::PE }
       it { expect(subject.format).to eq :pe }
-      it { expect(subject.platform).to eq AppInfo::Platform::WINDOWS }
-      it { expect(subject.platform).to eq :windows }
+      it { expect(subject.manufacturer).to eq AppInfo::Manufacturer::MICROSOFT }
+      it { expect(subject.manufacturer).to eq :microsoft }
       it { expect(subject.device).to eq AppInfo::Device::WINDOWS }
-      it { expect(subject.device).to eq :windows }
+      it { expect(subject.device).to eq :microsoft }
       it { expect(subject.binary_file).not_to be_nil }
       it { expect(subject.size).to eq 415127 }
       it { expect(subject.size(human_size: true)).to eq "405.40 KB" }
@@ -65,10 +65,10 @@ describe AppInfo::PE do
       it { expect(subject.file).to eq file }
       it { expect(subject.format).to eq AppInfo::Format::PE }
       it { expect(subject.format).to eq :pe }
-      it { expect(subject.platform).to eq AppInfo::Platform::WINDOWS }
-      it { expect(subject.platform).to eq :windows }
+      it { expect(subject.manufacturer).to eq AppInfo::Manufacturer::MICROSOFT }
+      it { expect(subject.manufacturer).to eq :microsoft }
       it { expect(subject.device).to eq AppInfo::Device::WINDOWS }
-      it { expect(subject.device).to eq :windows }
+      it { expect(subject.device).to eq :microsoft }
       it { expect(subject.binary_file).not_to be_nil }
       it { expect(subject.size).to eq 293888 }
       it { expect(subject.size(human_size: true)).to eq "287.00 KB" }

--- a/spec/app_info/pe_spec.rb
+++ b/spec/app_info/pe_spec.rb
@@ -12,19 +12,25 @@ describe AppInfo::PE do
       it { expect(subject.manufacturer).to eq AppInfo::Manufacturer::MICROSOFT }
       it { expect(subject.manufacturer).to eq :microsoft }
       it { expect(subject.device).to eq AppInfo::Device::WINDOWS }
-      it { expect(subject.device).to eq :microsoft }
+      it { expect(subject.device).to eq :windows }
       it { expect(subject.binary_file).not_to be_nil }
       it { expect(subject.size).to eq 415127 }
       it { expect(subject.size(human_size: true)).to eq "405.40 KB" }
       it { expect(subject.binary_size).to eq 443392 }
       it { expect(subject.binary_size(human_size: true)).to eq "433.00 KB" }
+      it { expect(subject.name).to eq('TopBar') }
+      it { expect(subject.company_name).to eq('Dejan Stojanovic') }
+      it { expect(subject.archs).to eq('x64') }
       it { expect(subject.product_version).to eq('1.0.0') }
       it { expect(subject.release_version).to eq('1.0.0') }
       it { expect(subject.assembly_version).to eq('1.0.0.0') }
       it { expect(subject.build_version).to eq('1.0.0.0') }
-      it { expect(subject.name).to eq('TopBar') }
-      it { expect(subject.company_name).to eq('Dejan Stojanovic') }
-      it { expect(subject.archs).to eq('x64') }
+      it { expect(subject.special_build).to be_nil }
+      it { expect(subject.private_build).to be_nil }
+      it { expect(subject.original_filename).to eq('TopBar.dll') }
+      it { expect(subject.file_description).to eq('TopBar') }
+      it { expect(subject.internal_name).to eq('TopBar.dll') }
+      it { expect(subject.legal_trademarks).to be_nil }
       it { expect(subject.version_info).to be_kind_of(AppInfo::PE::VersionInfo) }
       it { expect(subject.pe).to be_kind_of(PEdump) }
 
@@ -68,19 +74,25 @@ describe AppInfo::PE do
       it { expect(subject.manufacturer).to eq AppInfo::Manufacturer::MICROSOFT }
       it { expect(subject.manufacturer).to eq :microsoft }
       it { expect(subject.device).to eq AppInfo::Device::WINDOWS }
-      it { expect(subject.device).to eq :microsoft }
+      it { expect(subject.device).to eq :windows }
       it { expect(subject.binary_file).not_to be_nil }
       it { expect(subject.size).to eq 293888 }
       it { expect(subject.size(human_size: true)).to eq "287.00 KB" }
       it { expect(subject.binary_size).to eq 293888 }
       it { expect(subject.binary_size(human_size: true)).to eq "287.00 KB" }
+      it { expect(subject.name).to eq('UPX') }
+      it { expect(subject.company_name).to eq('The UPX Team http://upx.sf.net') }
+      it { expect(subject.archs).to eq('x86') }
       it { expect(subject.product_version).to eq('3.08 (2011-12-12)') }
       it { expect(subject.release_version).to eq('3.08 (2011-12-12)') }
       it { expect(subject.assembly_version).to be_nil }
       it { expect(subject.build_version).to be_nil }
-      it { expect(subject.name).to eq('UPX') }
-      it { expect(subject.company_name).to eq('The UPX Team http://upx.sf.net') }
-      it { expect(subject.archs).to eq('x86') }
+      it { expect(subject.special_build).to be_nil }
+      it { expect(subject.private_build).to be_nil }
+      it { expect(subject.original_filename).to eq('upx.exe') }
+      it { expect(subject.file_description).to eq('UPX executable packer') }
+      it { expect(subject.internal_name).to eq('upx.exe') }
+      it { expect(subject.legal_trademarks).to be_nil }
       it { expect(subject.version_info).to be_kind_of(AppInfo::PE::VersionInfo) }
       it { expect(subject.pe).to be_kind_of(PEdump) }
 

--- a/spec/app_info/proguard_spec.rb
+++ b/spec/app_info/proguard_spec.rb
@@ -9,10 +9,10 @@ describe AppInfo::Proguard do
     context 'parse' do
       it { expect(subject.format).to eq AppInfo::Format::PROGUARD }
       it { expect(subject.format).to eq :proguard }
-      it { expect(subject.platform).to eq AppInfo::Platform::GOOGLE }
-      it { expect(subject.platform).to eq :google }
-      it { expect(subject.opera_system).to eq AppInfo::OperaSystem::ANDROID }
-      it { expect(subject.opera_system).to eq :android }
+      it { expect(subject.manufacturer).to eq AppInfo::Manufacturer::GOOGLE }
+      it { expect(subject.manufacturer).to eq :google }
+      it { expect(subject.platform).to eq AppInfo::Platform::ANDROID }
+      it { expect(subject.platform).to eq :android }
       it { expect{ subject.device }.to raise_error NotImplementedError }
       it { expect(subject.uuid).to eq '81384aeb-4837-5f73-a771-417b4399a483' }
       it { expect(subject.mapping?).to be true }
@@ -35,10 +35,10 @@ describe AppInfo::Proguard do
     context 'parse' do
       it { expect(subject.format).to eq AppInfo::Format::PROGUARD }
       it { expect(subject.format).to eq :proguard }
-      it { expect(subject.platform).to eq AppInfo::Platform::GOOGLE }
-      it { expect(subject.platform).to eq :google }
-      it { expect(subject.opera_system).to eq AppInfo::OperaSystem::ANDROID }
-      it { expect(subject.opera_system).to eq :android }
+      it { expect(subject.manufacturer).to eq AppInfo::Manufacturer::GOOGLE }
+      it { expect(subject.manufacturer).to eq :google }
+      it { expect(subject.platform).to eq AppInfo::Platform::ANDROID }
+      it { expect(subject.platform).to eq :android }
       it { expect{ subject.device }.to raise_error NotImplementedError }
       it { expect(subject.uuid).to eq '81384aeb-4837-5f73-a771-417b4399a483' }
       it { expect(subject.mapping?).to be true }


### PR DESCRIPTION
Revoke a minor changes in #58 

- Rename `.platform` to `.manufacturer`
- Rename `.opera_sytem` to `.platform`